### PR TITLE
[issue: 116] Don't rebuild the swagger spec on every access

### DIFF
--- a/kernel_gateway/services/swagger/handlers.py
+++ b/kernel_gateway/services/swagger/handlers.py
@@ -16,6 +16,7 @@ class SwaggerSpecHandler(TokenAuthorizationMixin,
     """Handles requests for the Swagger specification of a notebook defined
     API.
     """
+    output = None
 
     def initialize(self, notebook_path, source_cells, kernel_spec):
         """Builds the spec for the notebook-defined API.
@@ -29,11 +30,12 @@ class SwaggerSpecHandler(TokenAuthorizationMixin,
         kernel_spec : str
             Name of the notebook kernel language
         """
-        spec_builder = SwaggerSpecBuilder(kernel_spec)
-        for source_cell in source_cells:
-            spec_builder.add_cell(source_cell)
-        spec_builder.set_title(notebook_path)
-        self.output = json.dumps(spec_builder.build())
+        if self.output is None:
+            spec_builder = SwaggerSpecBuilder(kernel_spec)
+            for source_cell in source_cells:
+                spec_builder.add_cell(source_cell)
+            spec_builder.set_title(notebook_path)
+            SwaggerSpecHandler.output = json.dumps(spec_builder.build())
 
     def get(self, **kwargs):
         """Responds with the spec in JSON format."""

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -5,6 +5,7 @@ import logging
 import unittest
 import os
 from kernel_gateway.gatewayapp import KernelGatewayApp, ioloop
+from ..services.swagger.handlers import SwaggerSpecHandler
 from tornado.testing import AsyncHTTPTestCase, LogTrapTestCase
 
 RESOURCES = os.path.join(os.path.dirname(__file__), 'resources')
@@ -63,6 +64,8 @@ class TestGatewayAppBase(AsyncHTTPTestCase, LogTrapTestCase):
     def tearDown(self):
         if self.app:
             self.app.shutdown()
+        # Make sure the generated Swagger output is reset for subsequent tests
+        SwaggerSpecHandler.output = None
         super(TestGatewayAppBase, self).tearDown()
 
     def get_new_ioloop(self):

--- a/kernel_gateway/tests/test_notebook_http.py
+++ b/kernel_gateway/tests/test_notebook_http.py
@@ -6,6 +6,7 @@ import sys
 import json
 
 from .test_gatewayapp import TestGatewayAppBase, RESOURCES
+from ..services.swagger.handlers import SwaggerSpecHandler
 from tornado.testing import gen_test
 
 class TestDefaults(TestGatewayAppBase):
@@ -390,6 +391,7 @@ class TestSwaggerSpec(TestGatewayAppBase):
         result = json.loads(response.body.decode('UTF-8'))
         self.assertEqual(response.code, 200, "Swagger spec endpoint did not return the correct status code")
         self.assertEqual(result, expected_response, "Swagger spec endpoint did not return the correct value")
+        self.assertIsNotNone(SwaggerSpecHandler.output, "Swagger spec output wasn't cached for later requests")
 
 class TestBaseURL(TestGatewayAppBase):
     def setup_app(self):


### PR DESCRIPTION
Cache the swagger output in a class variable and make sure it is cleared between tests.

(c) Copyright IBM Corp. 2016