### PR TITLE
[Issue: 110] Set env vars for kernels

### DIFF
--- a/kernel_gateway/tests/resources/kernel_api2.ipynb
+++ b/kernel_gateway/tests/resources/kernel_api2.ipynb
@@ -16,7 +16,7 @@
    },
    "outputs": [],
    "source": [
-    "import json"
+    "import os, json"
    ]
   },
   {
@@ -440,6 +440,18 @@
    "source": [
     "# GET /multi\n",
     "print('x is {}'.format(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# GET /env_kernel_gateway\n",
+    "print('KERNEL_GATEWAY is {}'.format(os.getenv('KERNEL_GATEWAY')))"
    ]
   }
  ],

--- a/kernel_gateway/tests/resources/kernel_api3.ipynb
+++ b/kernel_gateway/tests/resources/kernel_api3.ipynb
@@ -16,7 +16,7 @@
    },
    "outputs": [],
    "source": [
-    "import json"
+    "import os, json"
    ]
   },
   {
@@ -440,6 +440,18 @@
    "source": [
     "# GET /multi\n",
     "print('x is {}'.format(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# GET /env_kernel_gateway\n",
+    "print('KERNEL_GATEWAY is {}'.format(os.getenv('KERNEL_GATEWAY')))"
    ]
   }
  ],

--- a/kernel_gateway/tests/test_notebook_http.py
+++ b/kernel_gateway/tests/test_notebook_http.py
@@ -221,6 +221,18 @@ class TestDefaults(TestGatewayAppBase):
         self.assertEqual(response.code, 200, 'GET endpoint did not return 200.')
         self.assertEqual(response.body, b'x is 1\n', 'Unexpected body in response to GET.')
 
+    @gen_test
+    def test_kernel_gateway_environment_set(self):
+        """GET HTTP method should be callable with multiple query params"""
+        response = yield self.http_client.fetch(
+            self.get_url('/env_kernel_gateway'),
+            method='GET',
+            raise_error=False
+        )
+        self.assertEqual(response.code, 200, 'GET endpoint did not return 200.')
+        self.assertEqual(response.body, b'KERNEL_GATEWAY is 1\n', 'Unexpected body in response to GET.')
+
+
 class TestSourceDownload(TestGatewayAppBase):
     """Tests gateway behavior when notebook download is allowed."""
     def setup_app(self):


### PR DESCRIPTION
    Set a KERNEL_GATEWAY environment variable when launching kernels.
(c) Copyright IBM Corp. 2016