### PR TITLE
Use latest version of Sphinx to fix "Edit on GitHub"

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,6 @@
 name: kernel_gateway_docs
 dependencies:
-- sphinx>=1.3
+- sphinx>=1.3.6
 - sphinx_rtd_theme
 - jinja2
 - tornado

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,5 @@
 name: kernel_gateway_docs
 dependencies:
-- sphinx>=1.3.6
 - sphinx_rtd_theme
 - jinja2
 - tornado
@@ -9,6 +8,7 @@ dependencies:
 - notebook
 - ipykernel
 - pip:
+    - sphinx>=1.3.6
     - sphinxcontrib_spelling
     - pyenchant
     - jupyter_kernel_gateway

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,5 @@
 conda:
-    file: docs/conda_env.yml
+    file: docs/environment.yml
 python:
     version: 3
   


### PR DESCRIPTION
This PR fixes the issue found by @parente where RTD's "Edit on GitHub" was not correctly redirecting to markdown source and throwing a 404 instead. The cause was an underlying bug in Sphinx which has been fixed as 1.3.6.

I've updated our version of Sphinx to 1.3.6 or greater.