### PR TITLE
Simplify custom default kernel logic

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -252,11 +252,17 @@ class KernelGatewayApp(JupyterApp):
             # Note: must be set before instantiating a SeedingMappingKernelManager
             self.seed_notebook = self._load_notebook(self.seed_uri)
 
+        # Only pass a default kernel name when one is provided. Otherwise,
+        # adopt whatever default the kernel manager wants to use.
+        kwargs = {}
+        if self.default_kernel_name:
+            kwargs['default_kernel_name'] = self.default_kernel_name
         self.kernel_manager = SeedingMappingKernelManager(
             parent=self,
             log=self.log,
             connection_dir=self.runtime_dir,
-            kernel_spec_manager=self.kernel_spec_manager
+            kernel_spec_manager=self.kernel_spec_manager,
+            **kwargs
         )
 
         self.activity_manager = ActivityManager(

--- a/kernel_gateway/services/kernels/handlers.py
+++ b/kernel_gateway/services/kernels/handlers.py
@@ -27,7 +27,7 @@ class MainKernelHandler(TokenAuthorizationMixin,
 
         Raises
         ------
-        tonrado.web.HTTPError
+        tornado.web.HTTPError
             402 Payment Required (for lack of a better HTTP error code and
             mimicking what Google does) if the limit is reached
         """
@@ -56,24 +56,6 @@ class MainKernelHandler(TokenAuthorizationMixin,
         else:
             super(MainKernelHandler, self).get()
 
-    def get_json_body(self):
-        """Overrides the super class method to honor the configured default
-        kernel name when one is not included in the JSON body of the request.
-
-        Returns
-        -------
-        dict
-            Model object representing information about the requested kernel
-        """
-        model = super(MainKernelHandler, self).get_json_body()
-        if 'kg_default_kernel_name' in self.settings and self.settings['kg_default_kernel_name'] is not '':
-            if model is None:
-                model = {
-                    'name': self.settings['kg_default_kernel_name']
-                }
-            else:
-                model.setdefault('name', self.settings['kg_default_kernel_name'])
-        return model
 
 class KernelHandler(TokenAuthorizationMixin,
                     CORSMixin,

--- a/kernel_gateway/tests/test_jupyter_websocket.py
+++ b/kernel_gateway/tests/test_jupyter_websocket.py
@@ -348,21 +348,6 @@ class TestDefaults(TestJupyterWebsocket):
         ws.close()
 
     @gen_test
-    def test_default_kernel_name(self):
-        """The default kernel name should be used on empty requests."""
-        app = self.get_app()
-        app.settings['kg_default_kernel_name'] = 'fake-kernel'
-        # Request without an explicit kernel name
-        response = yield self.http_client.fetch(
-            self.get_url('/api/kernels'),
-            method='POST',
-            body='',
-            raise_error=False
-        )
-        self.assertEqual(response.code, 500)
-        self.assertTrue('raise NoSuchKernel' in str(response.body))
-
-    @gen_test
     def test_no_discovery(self):
         """The list of kernels / sessions should be forbidden by default."""
         response = yield self.http_client.fetch(
@@ -461,6 +446,24 @@ class TestDefaults(TestJupyterWebsocket):
         body = json_decode(response.body)
         self.assertEqual(response.code, 404)
         self.assertEqual(body['reason'], 'Not Found')
+
+class TestCustomDefaultKernel(TestJupyterWebsocket):
+    """Tests gateway behavior when setting a custom default kernelspec."""
+    def setup_app(self):
+        self.app.default_kernel_name = 'fake-kernel'
+
+    @gen_test
+    def test_default_kernel_name(self):
+        """The default kernel name should be used on empty requests."""
+        # Request without an explicit kernel name
+        response = yield self.http_client.fetch(
+            self.get_url('/api/kernels'),
+            method='POST',
+            body='',
+            raise_error=False
+        )
+        self.assertEqual(response.code, 500)
+        self.assertTrue('raise NoSuchKernel' in str(response.body))
 
 class TestEnableDiscovery(TestJupyterWebsocket):
     """Tests gateway behavior with kernel listing enabled."""


### PR DESCRIPTION
No need for custom get_json_body, just set the default on the kernel manager instance. Noticed this while working on #128 