### PR TITLE
Support env vars in requests to spawn kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: bash clean dev help install sdist test
 
-IMAGE:=jupyter/pyspark-notebook:a388c4a66fd4
+IMAGE:=jupyter/pyspark-notebook:918deae45315
 
 DOCKER_ARGS?=
 define DOCKER

--- a/kernel_gateway/services/kernels/manager.py
+++ b/kernel_gateway/services/kernels/manager.py
@@ -96,7 +96,7 @@ class SeedingMappingKernelManager(MappingKernelManager):
         return kernel_id
 
 class KernelGatewayIOLoopKernelManager(IOLoopKernelManager):
-    """Extends the IOLoopKernelManagers used by the SeedingMappingKernelManager
+    """Extends the IOLoopKernelManager used by the SeedingMappingKernelManager
     to include the environment variable 'KERNEL_GATEWAY' set to '1', indicating
     that the notebook is executing within a Jupyter Kernel Gateway
     """

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup_args = dict(
     ],
     install_requires=[
         'jupyter_core>=4.0, <5.0',
-        'jupyter_client>=4.0, <5.0',
+        'jupyter_client>=4.2.0, <5.0',
         'notebook>=4.0, <5.0',
         'requests>=2.7, <3.0'
     ],


### PR DESCRIPTION
* Hack around lack of access to the start_kernel method in the base class with an override
* Whitelist KERNEL_ prefixed vars, blacklist everything else
* Add test case

Fixes #128 