### PR TITLE
Remove KG_AUTH_TOKEN from kernel env

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,3 +7,7 @@ RUN pip install nose traitlets==4.2.0
 # Setup a sphinx environment for doc building
 COPY docs/environment.yml /tmp
 RUN conda env create -f /tmp/environment.yml
+
+# Add to the python2 environment for testing
+RUN bash -c 'source activate python2 && \
+    conda install -y requests nose'

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ sdist: ## Build a dist/*.tar.gz source distribution
 
 test: test-python3 ## Run tests on Python 3 in a docker container
 
-test-python2: PRE_CMD:=source activate python2; pip install requests;
+test-python2: PRE_CMD:=source activate python2;
 test-python2: _test ## Run tests on Python 2 in a docker container
 
 test-python3: _test

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,7 @@
 name: kernel_gateway_docs
 dependencies:
 - sphinx_rtd_theme
+- pyzmq
 - pip:
     - sphinx>=1.3.6
     - recommonmark

--- a/kernel_gateway/services/kernels/manager.py
+++ b/kernel_gateway/services/kernels/manager.py
@@ -97,10 +97,16 @@ class SeedingMappingKernelManager(MappingKernelManager):
         raise gen.Return(kernel_id)
 
 class KernelGatewayIOLoopKernelManager(IOLoopKernelManager):
-    """Extends the IOLoopKernelManager used by the SeedingMappingKernelManager
-    to include the environment variable 'KERNEL_GATEWAY' set to '1', indicating
-    that the notebook is executing within a Jupyter Kernel Gateway
+    """Extends the IOLoopKernelManager used by the SeedingMappingKernelManager.
+    
+    Sets the environment variable 'KERNEL_GATEWAY' to '1' to indicate that the
+    kernel is executing within a Jupyter Kernel Gateway instance. Removes the
+    KG_AUTH_TOKEN from the environment variables passed to the kernel when it 
+    starts.
     """
     def _launch_kernel(self, kernel_cmd, **kw):
-        kw['env']['KERNEL_GATEWAY'] = '1'
+        env = kw['env']
+        env['KERNEL_GATEWAY'] = '1'
+        if 'KG_AUTH_TOKEN' in env:
+            del env['KG_AUTH_TOKEN']
         return super(KernelGatewayIOLoopKernelManager, self)._launch_kernel(kernel_cmd, **kw)


### PR DESCRIPTION
Went with removing the one and only config env var that has sensitive information in it today instead of `KG_*` which might remove more than expected.

Fixes #164 