### PR TITLE
[Issue: 103] Refactor mode-specific traitlets

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -33,10 +33,6 @@ KernelGatewayApp options
 --KernelGatewayApp.allow_methods=<Unicode>
     Default: ''
     Sets the Access-Control-Allow-Methods header. (KG_ALLOW_METHODS env var)
---KernelGatewayApp.allow_notebook_download=<Bool>
-    Default: False
-    Optional API to download the notebook source code in notebook-http mode,
-    defaults to not allow (KG_ALLOW_NOTEBOOK_DOWNLOAD env var)
 --KernelGatewayApp.allow_origin=<Unicode>
     Default: ''
     Sets the Access-Control-Allow-Origin header. (KG_ALLOW_ORIGIN env var)
@@ -74,11 +70,6 @@ KernelGatewayApp options
 --KernelGatewayApp.ip=<Unicode>
     Default: ''
     IP address on which to listen (KG_IP env var)
---KernelGatewayApp.list_kernels=<Bool>
-    Default: False
-    Permits listing of the running kernels using API endpoints /api/kernels and
-    /api/sessions (KG_LIST_KERNELS env var). Note: Jupyter Notebook allows this
-    by default but kernel gateway does not.
 --KernelGatewayApp.log_datefmt=<Unicode>
     Default: '%Y-%m-%d %H:%M:%S'
     The date format used by logging formatters for %(asctime)s
@@ -111,4 +102,22 @@ KernelGatewayApp options
     Default: ''
     Runs the notebook (.ipynb) at the given URI on every kernel launched.
     (KG_SEED_URI env var)
+
+
+
+JupyterWebsocketPersonality options
+-----------------------------------
+--JupyterWebsocketPersonality.list_kernels=<Bool>
+    Default: False
+    Permits listing of the running kernels using API endpoints /api/kernels and
+    /api/sessions (KG_LIST_KERNELS env var). Note: Jupyter Notebook allows this
+    by default but kernel gateway does not.
+
+
+NotebookHTTPPersonality options
+-------------------------------
+--NotebookHTTPPersonality.allow_notebook_download=<Bool>
+    Default: False
+    Optional API to download the notebook source code in notebook-http mode,
+    defaults to not allow (KG_ALLOW_NOTEBOOK_DOWNLOAD env var)
 ```

--- a/kernel_gateway/jupyter_websocket/__init__.py
+++ b/kernel_gateway/jupyter_websocket/__init__.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 """Jupyter websocket personality for the Kernel Gateway"""
 
+import os
 from ..base.handlers import default_handlers as default_base_handlers
 from ..services.activity.handlers import ActivityHandler
 from ..services.kernels.pool import KernelPool
@@ -10,12 +11,23 @@ from ..services.kernelspecs.handlers import default_handlers as default_kernelsp
 from ..services.sessions.handlers import default_handlers as default_session_handlers
 from .handlers import default_handlers as default_api_handlers
 from notebook.utils import url_path_join
+from traitlets import Bool, default
 from traitlets.config.configurable import LoggingConfigurable
 
 class JupyterWebsocketPersonality(LoggingConfigurable):
     """Personality for standard websocket functionality, registering
     endpoints that are part of the Jupyter Kernel Gateway API
     """
+
+    list_kernels_env = 'KG_LIST_KERNELS'
+    list_kernels = Bool(config=True,
+        help="""Permits listing of the running kernels using API endpoints /api/kernels
+            and /api/sessions (KG_LIST_KERNELS env var). Note: Jupyter Notebook
+            allows this by default but kernel gateway does not."""
+    )
+    @default('list_kernels')
+    def list_kernels_default(self):
+        return os.getenv(self.list_kernels_env, 'False') == 'True'
 
     def init_configurables(self):
         self.kernel_pool = KernelPool(

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -39,8 +39,6 @@ class TestGatewayAppConfig(unittest.TestCase):
         os.environ['KG_SEED_URI'] = 'fake-notebook.ipynb'
         os.environ['KG_PRESPAWN_COUNT'] = '1'
         os.environ['KG_DEFAULT_KERNEL_NAME'] = 'fake_kernel'
-        os.environ['KG_LIST_KERNELS'] = 'True'
-        os.environ['KG_ALLOW_NOTEBOOK_DOWNLOAD'] = 'True'
 
         app = KernelGatewayApp()
 
@@ -59,8 +57,6 @@ class TestGatewayAppConfig(unittest.TestCase):
         self.assertEqual(app.seed_uri, 'fake-notebook.ipynb')
         self.assertEqual(app.prespawn_count, 1)
         self.assertEqual(app.default_kernel_name, 'fake_kernel')
-        self.assertEqual(app.list_kernels, True)
-        self.assertEqual(app.allow_notebook_download, True)
 
 class TestGatewayAppBase(AsyncHTTPTestCase, LogTrapTestCase):
     """Base class for integration style tests using HTTP/Websockets against an
@@ -90,11 +86,17 @@ class TestGatewayAppBase(AsyncHTTPTestCase, LogTrapTestCase):
         self.app = KernelGatewayApp(log_level=logging.CRITICAL)
         self.setup_app()
         self.app.init_configurables()
+        self.setup_configurables()
         self.app.init_webapp()
         return self.app.web_app
 
     def setup_app(self):
         """Override to configure KernelGatewayApp instance before initializing
         configurables and the web app.
+        """
+        pass
+
+    def setup_configurables(self):
+        """Override to configure further settings, such as the personality.
         """
         pass

--- a/kernel_gateway/tests/test_jupyter_websocket.py
+++ b/kernel_gateway/tests/test_jupyter_websocket.py
@@ -560,9 +560,9 @@ class TestCustomDefaultKernel(TestJupyterWebsocket):
 
 class TestEnableDiscovery(TestJupyterWebsocket):
     """Tests gateway behavior with kernel listing enabled."""
-    def setup_app(self):
+    def setup_configurables(self):
         """Enables kernel listing for all tests."""
-        self.app.list_kernels = True
+        self.app.personality.list_kernels = True
 
     @gen_test
     def test_enable_kernel_list(self):
@@ -614,7 +614,10 @@ class TestBaseURL(TestJupyterWebsocket):
     def setup_app(self):
         """Sets the custom base URL and enables kernel listing."""
         self.app.base_url = '/fake/path'
-        self.app.list_kernels = True
+
+    def setup_configurables(self):
+        """Enables kernel listing for all tests."""
+        self.app.personality.list_kernels = True
 
     @gen_test
     def test_base_url(self):
@@ -777,9 +780,9 @@ class TestKernelLanguageSupport(TestJupyterWebsocket):
 
 class TestActivityAPI(TestJupyterWebsocket):
     """Tests gateway behavior when the activity API is enabled."""
-    def setup_app(self):
+    def setup_configurables(self):
         """Enables kernel listing so the activity API is available."""
-        self.app.list_kernels = True
+        self.app.personality.list_kernels = True
 
     @gen_test
     def test_api_lists_kernels_with_flag_set(self):

--- a/kernel_gateway/tests/test_notebook_http.py
+++ b/kernel_gateway/tests/test_notebook_http.py
@@ -242,7 +242,9 @@ class TestSourceDownload(TestGatewayAppBase):
         self.app.api = 'kernel_gateway.notebook_http'
         self.app.seed_uri = os.path.join(RESOURCES,
                                          'kernel_api{}.ipynb'.format(sys.version_info.major))
-        self.app.allow_notebook_download = True
+
+    def setup_configurables(self):
+        self.app.personality.allow_notebook_download = True
 
     @gen_test
     def test_download_notebook_source(self):
@@ -414,9 +416,11 @@ class TestBaseURL(TestGatewayAppBase):
         """Sets the custom base URL and enables the notebook-defined API."""
         self.app.base_url = '/fake/path'
         self.app.api = 'kernel_gateway.notebook_http'
-        self.app.allow_notebook_download = True
         self.app.seed_uri = os.path.join(RESOURCES,
                                          'kernel_api{}.ipynb'.format(sys.version_info.major))
+
+    def setup_configurables(self):
+        self.app.personality.allow_notebook_download = True
 
     @gen_test
     def test_base_url(self):


### PR DESCRIPTION
  Move mode-specific traitlets into their respective personalities.

  Personality traitlets created with the tag "config=True" will have
  their values set into the web app's settings dictionary, keeping
  handlers decoupled from any specific personalities.
(c) Copyright IBM Corp. 2016