### PR TITLE
[WIP] Add support for additional API cell parsers

### DIFF
--- a/kernel_gateway/notebook_http/__init__.py
+++ b/kernel_gateway/notebook_http/__init__.py
@@ -3,13 +3,15 @@
 """Notebook HTTP personality for the Kernel Gateway"""
 
 import os
+import tornado
+import importlib
 from ..base.handlers import default_handlers as default_base_handlers
 from ..services.kernels.pool import ManagedKernelPool
 from .cell.parser import APICellParser
 from .swagger.handlers import SwaggerSpecHandler
 from .handlers import NotebookAPIHandler, parameterize_path, NotebookDownloadHandler
 from notebook.utils import url_path_join
-from traitlets import Bool, default
+from traitlets import Bool, Unicode, default
 from traitlets.config.configurable import LoggingConfigurable
 
 class NotebookHTTPPersonality(LoggingConfigurable):
@@ -18,7 +20,26 @@ class NotebookHTTPPersonality(LoggingConfigurable):
     """
     def __init__(self, *args, **kwargs):
         super(NotebookHTTPPersonality, self).__init__(*args, **kwargs)
-        self.api_parser = APICellParser(self.parent.kernel_manager.seed_kernelspec)
+        cell_parser_module = self._load_module(self.cell_parser)
+        func = getattr(cell_parser_module, 'create_parser')
+        self.api_parser = func(parent=self, log=self.log, kernelspec=self.parent.kernel_manager.seed_kernelspec, notebook_cells=self.parent.seed_notebook.cells)
+
+    cell_parser_env = 'KG_CELL_PARSER'
+    cell_parser = Unicode('kernel_gateway.notebook_http.cell.parser',
+        config=True,
+        help=""" Determines which module is used to parse the notebook for endpoints and
+            documentation. Valid module names include 'kernel_gateway.notebook_http.cell.parser'
+            and 'kernel_gateway.notebook_http.swagger.parser'. (KG_CELL_PARSER env var)
+            """
+    )
+    @default('cell_parser')
+    def cell_parser_default(self):
+        return os.getenv(self.cell_parser_env, 'kernel_gateway.notebook_http.cell.parser')
+
+    def _load_module(self, module_name):
+        '''Tries to import the given module name'''
+        _module = importlib.import_module(module_name)
+        return _module
 
     allow_notebook_download_env = 'KG_ALLOW_NOTEBOOK_DOWNLOAD'
     allow_notebook_download = Bool(
@@ -29,7 +50,18 @@ class NotebookHTTPPersonality(LoggingConfigurable):
     def allow_notebook_download_default(self):
         return os.getenv(self.allow_notebook_download_env, 'False') == 'True'
 
+    static_path_env = 'KG_STATIC_PATH'
+    static_path = Unicode(None,
+        config=True,
+        allow_none=True,
+        help="Serve static files on disk in the given path as /public, defaults to not serve"
+    )
+    @default('static_path')
+    def static_path_default(self):
+        return os.getenv(self.static_path_env)
+
     def init_configurables(self):
+        """Create a managed kernel pool"""
         self.kernel_pool = ManagedKernelPool(
             self.parent.prespawn_count,
             self.parent.kernel_manager
@@ -43,10 +75,22 @@ class NotebookHTTPPersonality(LoggingConfigurable):
         handlers = []
         # Register the NotebookDownloadHandler if configuration allows
         if self.allow_notebook_download:
+            path = url_path_join('/', self.parent.base_url, r'/_api/source')
+            self.log.info('Registering resource: {}, methods: (GET)'.format(path))
             handlers.append((
-                url_path_join('/', self.parent.base_url, r'/_api/source'),
+                path,
                 NotebookDownloadHandler,
                 {'path': self.parent.seed_uri}
+            ))
+
+        # Register a static path handler if configuration allows
+        if self.static_path is not None:
+            path = url_path_join('/', self.parent.base_url, r'/public/(.*)')
+            self.log.info('Registering resource: {}, methods: (GET)'.format(path))
+            handlers.append((
+                path,
+                tornado.web.StaticFileHandler,
+                {'path': self.static_path}
             ))
 
         # Discover the notebook endpoints and their implementations
@@ -72,12 +116,15 @@ class NotebookHTTPPersonality(LoggingConfigurable):
             handlers.append((parameterized_path, NotebookAPIHandler, handler_args))
 
         # Register the swagger API spec handler
+        self.log.info('Registering endpoint_path: {}'.format(
+            r'/_api/spec/swagger.json')
+        )
         handlers.append(
             (url_path_join('/', self.parent.base_url, r'/_api/spec/swagger.json'),
             SwaggerSpecHandler, {
                 'notebook_path' : self.parent.seed_uri,
-                'source_cells': self.parent.kernel_manager.seed_source,
-                'kernel_spec' : self.parent.kernel_manager.seed_kernelspec
+                'source_cells': self.parent.seed_notebook.cells,
+                'cell_parser' : self.api_parser
         }))
 
         # Add the 404 catch-all last

--- a/kernel_gateway/notebook_http/request_utils.py
+++ b/kernel_gateway/notebook_http/request_utils.py
@@ -31,7 +31,7 @@ def parameterize_path(path):
     Parameters
     ----------
     path : str
-        URL path with `/:name` segements
+        URL path with `/:name` segments
 
     Returns
     -------

--- a/kernel_gateway/notebook_http/swagger/builders.py
+++ b/kernel_gateway/notebook_http/swagger/builders.py
@@ -3,8 +3,6 @@
 """Class for building a Swagger spec from a notebook-defined API."""
 
 import os
-from ..cell.parser import APICellParser
-
 
 class SwaggerSpecBuilder(object):
     """Builds a Swagger specification.
@@ -21,9 +19,9 @@ class SwaggerSpecBuilder(object):
     value : dict
         Python object representation of the Swagger spec
     """
-    def __init__(self, kernel_spec):
-        self.cell_parser = APICellParser(kernel_spec)
-        self.value = { 'swagger' : '2.0', 'paths' : {}, 'info' : {'version' : '0.0.0', 'title' : 'Default Title'} }
+    def __init__(self, cell_parser):
+        self.cell_parser = cell_parser
+        self.value = self.cell_parser.get_default_api_spec()
 
     def add_cell(self, cell_source):
         """Parses a notebook cell for API annotations.
@@ -37,25 +35,23 @@ class SwaggerSpecBuilder(object):
         """
         if self.cell_parser.is_api_cell(cell_source):
             path_name, verb = self.cell_parser.get_cell_endpoint_and_verb(cell_source)
-            path_value = {
-                'responses' : {
-                    200 : { 'description': 'Success'}
-                }
-            }
+            path_value = self.cell_parser.get_path_content(cell_source)
             if not path_name in self.value['paths']:
                 self.value['paths'][path_name] = {}
             self.value['paths'][path_name][verb.lower()] = path_value
 
-    def set_title(self, path):
-        """Stores the root of a notebook filename as the API title.
+    def set_default_title(self, path):
+        """Stores the root of a notebook filename as the API title, if one is
+        not already present.
 
         Parameters
         ----------
         path : url
             Path to the notebook file defining the API
         """
-        basename = os.path.basename(path)
-        self.value['info']['title'] = basename.split('.')[0] if basename.find('.') > 0 else basename
+        if 'info' in self.value and 'title' not in self.value['info']:
+            basename = os.path.basename(path)
+            self.value['info']['title'] = basename.split('.')[0] if basename.find('.') > 0 else basename
 
     def build(self):
         """Gets the specification.

--- a/kernel_gateway/notebook_http/swagger/handlers.py
+++ b/kernel_gateway/notebook_http/swagger/handlers.py
@@ -18,7 +18,7 @@ class SwaggerSpecHandler(TokenAuthorizationMixin,
     """
     output = None
 
-    def initialize(self, notebook_path, source_cells, kernel_spec):
+    def initialize(self, notebook_path, source_cells, cell_parser):
         """Builds the spec for the notebook-defined API.
 
         Parameters
@@ -26,15 +26,16 @@ class SwaggerSpecHandler(TokenAuthorizationMixin,
         notebook_path : str
             Path to the notebook, used to set the API title
         source_cells : list
-            Source code cell strings
-        kernel_spec : str
-            Name of the notebook kernel language
+            code cells
+        cell_parser : obj
+            Parser that will return endpoints and documentation
         """
         if self.output is None:
-            spec_builder = SwaggerSpecBuilder(kernel_spec)
+            spec_builder = SwaggerSpecBuilder(cell_parser)
             for source_cell in source_cells:
-                spec_builder.add_cell(source_cell)
-            spec_builder.set_title(notebook_path)
+                if 'source' in source_cell:
+                    spec_builder.add_cell(source_cell['source'])
+            spec_builder.set_default_title(notebook_path)
             SwaggerSpecHandler.output = json.dumps(spec_builder.build())
 
     def get(self, **kwargs):

--- a/kernel_gateway/notebook_http/swagger/parser.py
+++ b/kernel_gateway/notebook_http/swagger/parser.py
@@ -1,0 +1,297 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Parser for notebook with a single markdown cell containing Swagger API definition."""
+
+import json
+import re
+from kernel_gateway.notebook_http.cell.parser import first_path_param_index, APICellParser
+from traitlets import default
+from traitlets.config.configurable import LoggingConfigurable
+
+def _swaggerlet_from_markdown(cell_source):
+    """ Pulls apart the first block comment of a cell's source,
+    then tries to parse it as a JSON object. If it contains a 'swagger'
+    property, returns it.
+    """
+    lines = cell_source.splitlines()
+    # pull out the first block comment
+    if len(lines) > 2:
+        for i in range(0, len(lines)):
+            if lines[i].startswith("```"):
+                lines = lines[i+1:]
+                break
+        for i in range(0, len(lines)):
+            if lines[i].startswith("```"):
+                lines = lines[:i]
+                break
+    # parse the comment as JSON and check for a "swagger" property
+    try:
+        json_comment = json.loads(''.join(lines))
+        if 'swagger' in json_comment:
+            return json_comment
+    except ValueError:
+        # not a swaggerlet
+        pass
+    return None
+
+class SwaggerCellParser(LoggingConfigurable):
+    """A utility class for parsing Jupyter code cells to find API annotations
+    of the form:
+
+    `COMMENT (ResponseInfo)? operationId: ID`
+
+    where:
+
+    * `COMMENT` is the single line comment character of the notebook kernel
+        language
+    * `ResponseInfo` is a literal token.
+    * `ID` is an operation's ID as documented in a Swagger comment block
+    * `operationId` is a literal token.
+
+    Attributes
+    ----------
+    kernelspec
+        Name of the kernelspec in the notebook to be parsed
+    kernelspec_comment_mapping : dict
+        Maps kernelspec names to language comment syntax
+    notebook_cells : list
+        The cells from the target notebook, one of which must contain a Swagger spec in a commented block
+    operation_indicator : str
+        Regex pattern for API annotations
+    operation_response_indicator : str
+        Regex pattern for API response metadata annotations
+    """
+    kernelspec_comment_mapping = {
+        None:'#',
+        'scala':'//'
+    }
+    operation_indicator = r'{}\s*operationId:\s*(.*)'
+    operation_response_indicator = r'{}\s*ResponseInfo\s+operationId:\s*(.*)'
+    notebook_cells = []
+
+    def __init__(self, *args, **kwargs):
+        super(SwaggerCellParser, self).__init__(*args, **kwargs)
+        try:
+            prefix = self.kernelspec_comment_mapping[self.kernelspec]
+        except KeyError:
+            prefix = self.kernelspec_comment_mapping[None]
+        self.kernelspec_operation_indicator = re.compile(self.operation_indicator.format(prefix))
+        self.kernelspec_operation_response_indicator = re.compile(self.operation_response_indicator.format(prefix))
+        self.swagger = dict()
+        operationIdsFound = []
+        operationIdsDeclared = []
+        for cell in self.notebook_cells:
+            if 'type' not in cell or cell['type'] == 'markdown':
+                json_swagger = _swaggerlet_from_markdown(cell['source'])
+                if json_swagger is not None:
+                    self.swagger.update(dict(json_swagger))
+            if 'type' not in cell or cell['type'] == 'code':
+                match = self.kernelspec_operation_indicator.match(cell['source'])
+                if match is not None:
+                    operationIdsFound.append(match.group(1).strip())
+        if len(self.swagger.values()) == 0:
+            self.log.warning('No Swagger documentation found')
+        if 'paths' in self.swagger:
+            for endpoint in self.swagger['paths'].keys():
+                for verb in self.swagger['paths'][endpoint].keys():
+                    if 'operationId' in self.swagger['paths'][endpoint][verb]:
+                        operationId = self.swagger['paths'][endpoint][verb]['operationId']
+                        operationIdsDeclared.append(operationId)
+            for operationId in operationIdsDeclared:
+                if operationId not in operationIdsFound:
+                    self.log.warning('Operation {} was declared but not referenced in a cell'.format(operationId))
+            for operationId in operationIdsFound:
+                if operationId not in operationIdsDeclared:
+                    self.log.warning('Operation {} was referenced in a cell but not declared'.format(operationId))
+        else:
+            self.log.warning('No paths documented in Swagger documentation')
+
+    def is_api_cell(self, cell_source):
+        """Gets if the cell source is documented as an API endpoint.
+
+        Parameters
+        ----------
+        cell_source
+            Source from a notebook cell
+
+        Returns
+        -------
+        bool
+            True if cell is annotated as an API endpoint, or is itself
+            a swaggerlet.
+        """
+        match = self.kernelspec_operation_indicator.match(cell_source)
+        return match is not None
+
+    def is_api_response_cell(self, cell_source):
+        """Gets if the cell source is annotated as defining API response
+        metadata.
+
+        Parameters
+        ----------
+        cell_source
+            Source from a notebook cell
+
+        Returns
+        -------
+        bool
+            True if cell is annotated as ResponseInfo
+        """
+        match = self.kernelspec_operation_response_indicator.match(cell_source)
+        return match is not None
+
+    def endpoints(self, source_cells, sort_func=first_path_param_index):
+        """Gets the list of all annotated endpoint HTTP paths and verbs.
+
+        Parameters
+        ----------
+        source_cells
+            List of source strings from notebook cells
+        sort_func
+            Function by which to sort the endpoint list
+
+        Returns
+        -------
+        list
+            List of tuples with the endpoint str as the first element of each
+            tuple and a dict mapping HTTP verbs to cell sources as the second
+            element of each tuple
+        """
+        endpoints = self._endpoint_verb_source_mappings(source_cells, self.kernelspec_operation_indicator)
+        sorted_keys = sorted(endpoints, key=sort_func, reverse=True)
+        return [(key, endpoints[key]) for key in sorted_keys]
+
+    def endpoint_responses(self, source_cells, sort_func=first_path_param_index):
+        """Gets the list of all annotated ResponseInfo HTTP paths and verbs.
+
+        Parameters
+        ----------
+        source_cells
+            List of source strings from notebook cells
+        sort_func
+            Function by which to sort the endpoint list
+
+        Returns
+        -------
+        list
+            List of tuples with the endpoint str as the first element of each
+            tuple and a dict mapping HTTP verbs to cell sources as the second
+            element of each tuple
+        """
+        endpoints = self._endpoint_verb_source_mappings(source_cells, self.kernelspec_operation_response_indicator)
+        sorted_keys = sorted(endpoints, key=sort_func, reverse=True)
+        return [(key, endpoints[key]) for key in sorted_keys]
+
+    def _endpoint_verb_source_mappings(self, source_cells, operationIdRegex):
+        """Gets a dict of all paths, verbs, and contents for the given cells,
+        using the given regex to find the relevant operationIds.
+
+        Parameters
+        ----------
+        source_cells
+            List of source strings from notebook cells
+        operationIdRegex
+            Regex for spotting a cell marked up with a match group that yields
+            a Swagger operationId.
+
+        Returns
+        -------
+        dict
+            Dict of dicts mapping the endpoint str to a HTTP verbs to concatenated
+            cell sources
+        """
+        mappings = {}
+        operationIds = {}
+        # find all of the mentioned operationIds and their concatenated source
+        for cell_source in source_cells:
+            matched = operationIdRegex.match(cell_source)
+            if matched is not None:
+                operationId = matched.group(1).strip()
+                # stripping trailing whitespace, could be a gotcha
+                operationIds.setdefault(operationId, '')
+                operationIds[operationId] += cell_source + '\n'
+
+        # go through the declared swagger and assign source values per referenced operationIds
+        for endpoint in self.swagger['paths'].keys():
+            for verb in self.swagger['paths'][endpoint].keys():
+                if 'operationId' in self.swagger['paths'][endpoint][verb] and self.swagger['paths'][endpoint][verb]['operationId'] in operationIds:
+                    operationId = self.swagger['paths'][endpoint][verb]['operationId']
+                    if 'parameters' in self.swagger['paths'][endpoint][verb]:
+                        endpoint_with_param = endpoint
+                        ## do we need to sort these names as well?
+                        for parameter in self.swagger['paths'][endpoint][verb]['parameters']:
+                            if 'name' in parameter:
+                                endpoint_with_param = '/:'.join([endpoint_with_param, parameter['name']])
+                        mappings.setdefault(endpoint_with_param, {}).setdefault(verb, '')
+                        mappings[endpoint_with_param][verb] = operationIds[operationId]
+                    else:
+                        mappings.setdefault(endpoint, {}).setdefault(verb, '')
+                        mappings[endpoint][verb] = operationIds[operationId]
+        return mappings
+
+    def get_cell_endpoint_and_verb(self, cell_source):
+        """Gets the HTTP path and verb from an annotated cell.
+
+        If the cell is not annotated with an operationId, or the known Swagger
+        doc doesn't reference the same operationId, returns (None, None)
+
+        Parameters
+        ----------
+        cell_source
+            Source from a notebook cell
+
+        Returns
+        -------
+        tuple
+            Endpoint str, HTTP verb str
+        """
+        matched = self.kernelspec_operation_indicator.match(cell_source)
+        if matched is not None:
+            operationId = matched.group(1)
+            # go through the declared operationIds to find corresponding endpoints, methods, and parameters
+            for endpoint in self.swagger['paths'].keys():
+                for verb in self.swagger['paths'][endpoint].keys():
+                    if 'operationId' in self.swagger['paths'][endpoint][verb] and self.swagger['paths'][endpoint][verb]['operationId'] == operationId:
+                        return (endpoint, verb)
+        return (None, None)
+
+    def get_path_content(self, cell_source):
+        """Gets the operation description for an API cell annotation.
+
+        Parameters
+        ----------
+        cell_source
+            Source from a notebook cell
+
+        Returns
+        -------
+        Object describing the supported operation. If the cell is not annotated,
+        just minimal response output guidance.
+        """
+        matched = self.kernelspec_operation_indicator.match(cell_source)
+        operationId = matched.group(1)
+        # go through the declared operationIds to find corresponding endpoints, methods, and parameters
+        for endpoint in self.swagger['paths'].keys():
+            for verb in self.swagger['paths'][endpoint].keys():
+                if 'operationId' in self.swagger['paths'][endpoint][verb] and self.swagger['paths'][endpoint][verb]['operationId'] == operationId:
+                    return self.swagger['paths'][endpoint][verb]
+        # mismatched operationId? return a default
+        return {
+            'responses' : {
+                200 : { 'description': 'Success'}
+            }
+        }
+
+    def get_default_api_spec(self):
+        """Gets the default minimum API spec to use when building a full spec
+        from the seed notebook's contents, preferably tak
+
+        dictionary
+            Dictionary with a root "swagger" property
+        """
+        if self.swagger is not None:
+            return self.swagger
+        return { 'swagger' : '2.0', 'paths' : {}, 'info' : {'version' : '0.0.0', 'title' : 'Default Title'} };
+
+def create_parser(*args, **kwargs):
+    return SwaggerCellParser(*args, **kwargs)

--- a/kernel_gateway/tests/notebook_http/cell/test_parser.py
+++ b/kernel_gateway/tests/notebook_http/cell/test_parser.py
@@ -26,7 +26,7 @@ class TestAPICellParser(unittest.TestCase):
         AssertionError
             If the parser did not create the correct regex
         """
-        parser = APICellParser(kernel_spec)
+        parser = APICellParser(kernelspec=kernel_spec)
         self.assertEqual(
             parser.kernelspec_api_indicator,
             re.compile(parser.api_indicator.format(expected_comment)),
@@ -47,7 +47,7 @@ class TestAPICellParser(unittest.TestCase):
 
     def test_is_api_cell(self):
         """Parser should correctly identify annotated API cells."""
-        parser = APICellParser('some_unknown_kernel')
+        parser = APICellParser(kernelspec='some_unknown_kernel')
         self.assertTrue(parser.is_api_cell('# GET /yes'), 'API cell was not detected')
         self.assertFalse(parser.is_api_cell('no'), 'API cell was not detected')
 
@@ -59,7 +59,7 @@ class TestAPICellParser(unittest.TestCase):
             '# GET /hello/:foo',
             '# PUT /hello/world'
         ]
-        parser = APICellParser('some_unknown_kernel')
+        parser = APICellParser(kernelspec='some_unknown_kernel')
         endpoints = parser.endpoints(source_cells)
         expected_values = ['/hello/world', '/hello/:foo', '/:foo']
 
@@ -86,7 +86,7 @@ class TestAPICellParser(unittest.TestCase):
             else:
                 return 2
 
-        parser = APICellParser('some_unknown_kernel')
+        parser = APICellParser(kernelspec='some_unknown_kernel')
         endpoints = parser.endpoints(source_cells, custom_sort_fun)
         expected_values = ['/+', '/a', '/1']
 
@@ -96,7 +96,7 @@ class TestAPICellParser(unittest.TestCase):
 
     def test_get_cell_endpoint_and_verb(self):
         """Parser should extract API endpoint and verb from cell annotations."""
-        parser = APICellParser('some_unknown_kernel')
+        parser = APICellParser(kernelspec='some_unknown_kernel')
         endpoint, verb = parser.get_cell_endpoint_and_verb('# GET /foo')
         self.assertEqual(endpoint, '/foo', 'Endpoint was not extracted correctly')
         self.assertEqual(verb, 'GET', 'Endpoint was not extracted correctly')
@@ -117,7 +117,7 @@ class TestAPICellParser(unittest.TestCase):
             'ignored',
             '# GET /foo/:bar'
         ]
-        parser = APICellParser('some_unknown_kernel')
+        parser = APICellParser(kernelspec='some_unknown_kernel')
         endpoints = parser.endpoints(source_cells)
         self.assertEqual(len(endpoints), 2)
         # for ease of testing
@@ -139,7 +139,7 @@ class TestAPICellParser(unittest.TestCase):
             'ignored',
             '# ResponseInfo GET /foo/:bar'
         ]
-        parser = APICellParser('some_unknown_kernel')
+        parser = APICellParser(kernelspec='some_unknown_kernel')
         endpoints = parser.endpoint_responses(source_cells)
         self.assertEqual(len(endpoints), 2)
         # for ease of testing

--- a/kernel_gateway/tests/notebook_http/swagger/test_builders.py
+++ b/kernel_gateway/tests/notebook_http/swagger/test_builders.py
@@ -2,16 +2,20 @@
 # Distributed under the terms of the Modified BSD License.
 """Tests for swagger spec generation."""
 
+import json
 import unittest
+from nose.tools import assert_not_equal
 from kernel_gateway.notebook_http.swagger.builders import SwaggerSpecBuilder
+from kernel_gateway.notebook_http.cell.parser import APICellParser
+from kernel_gateway.notebook_http.swagger.parser import SwaggerCellParser
 
 class TestSwaggerBuilders(unittest.TestCase):
     """Unit tests the swagger spec builder."""
     def test_add_title_adds_title_to_spec(self):
         """Builder should store an API title."""
         expected = 'Some New Title'
-        builder = SwaggerSpecBuilder('some_spec')
-        builder.set_title(expected)
+        builder = SwaggerSpecBuilder(APICellParser(kernelspec='some_spec'))
+        builder.set_default_title(expected)
         result = builder.build()
         self.assertEqual(result['info']['title'] ,expected,'Title was not set to new value')
 
@@ -24,14 +28,70 @@ class TestSwaggerBuilders(unittest.TestCase):
                 }
             }
         }
-        builder = SwaggerSpecBuilder('some_spec')
+        builder = SwaggerSpecBuilder(APICellParser(kernelspec='some_spec'))
         builder.add_cell('# GET /some/resource')
         result = builder.build()
         self.assertEqual(result['paths']['/some/resource'] ,expected,'Title was not set to new value')
 
-    def test_add_cell_does_not_add_non_api_cell_to_spec(self):
-        """Builder should store ignore non- API cells."""
-        builder = SwaggerSpecBuilder('some_spec')
-        builder.add_cell('regular code cell')
+    def test_all_swagger_preserved_in_spec(self):
+        """Builder should store the swagger documented cell."""
+        expected = '''
+        {
+            "swagger": "2.0",
+            "info" : {"version" : "0.0.0", "title" : "Default Title"},
+            "paths": {
+                "/some/resource": {
+                    "get": {
+                        "summary": "Get some resource",
+                        "description": "Get some kind of resource?",
+                        "operationId": "getSomeResource",
+                        "produces": [
+                            "application/json"
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "a resource",
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "400": {
+                                "description": "Error retrieving resources",
+                                "schema": {
+                                    "$ref": "#/definitions/error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        '''
+        builder = SwaggerSpecBuilder(SwaggerCellParser(kernelspec='some_spec', notebook_cells = [{"source":expected}]))
+        builder.add_cell(expected)
         result = builder.build()
-        self.assertEqual(len(result['paths']) , 0,'Title was not set to new value')
+        self.maxDiff = None
+        self.assertEqual(result['paths']['/some/resource']['get']['description'], json.loads(expected)['paths']['/some/resource']['get']['description'], 'description was not preserved')
+        self.assertTrue('info' in result, 'info was not preserved')
+        self.assertTrue('title' in result['info'], 'title was not present')
+        self.assertEqual(result['info']['title'], json.loads(expected)['info']['title'], 'title was not preserved')
+        self.assertEqual(json.dumps(result['paths']['/some/resource'], sort_keys=True), json.dumps(json.loads(expected)['paths']['/some/resource'], sort_keys=True), 'operations were not as expected')
+
+        new_title = 'new title. same contents.'
+        builder.set_default_title(new_title)
+        result = builder.build()
+        assert_not_equal(result['info']['title'], new_title, 'title should not have been changed')
+
+    def test_add_undocumented_cell_does_not_add_non_api_cell_to_spec(self):
+        """Builder should store ignore non-API cells."""
+        builder = SwaggerSpecBuilder(SwaggerCellParser(kernelspec='some_spec'))
+        builder.add_cell('regular code cell')
+        builder.add_cell('# regular commented cell')
+        result = builder.build()
+        self.assertEqual('paths' in result , 0, 'unexpected paths were found')

--- a/kernel_gateway/tests/notebook_http/swagger/test_parser.py
+++ b/kernel_gateway/tests/notebook_http/swagger/test_parser.py
@@ -1,0 +1,175 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for notebook cell parsing."""
+
+import unittest
+import re
+import sys
+from kernel_gateway.notebook_http.swagger.parser import SwaggerCellParser
+from kernel_gateway.notebook_http.cell.parser import APICellParser
+
+class TestSwaggerAPICellParser(unittest.TestCase):
+    """Unit tests the SwaggerCellParser class."""
+    def test_basic_swagger_parse(self):
+        """Parser should correctly identify Swagger cells."""
+        parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=[{"source":'```\n{"swagger":"2.0", "paths": {"": {"post": {"operationId": "foo", "parameters": [{"name": "foo"}]}}}}\n```\n'}])
+        self.assertTrue('swagger' in parser.swagger, 'Swagger doc was not detected')
+
+    def test_basic_is_api_cell(self):
+        """Parser should correctly identify operation cells."""
+        parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=[{"source":'```\n{"swagger":"2.0", "paths": {"": {"post": {"operationId": "foo", "parameters": [{"name": "foo"}]}}}}\n```\n'}])
+        self.assertTrue(parser.is_api_cell('#operationId:foo'), 'API cell was not detected with ' + str(parser.kernelspec_operation_indicator))
+        self.assertTrue(parser.is_api_cell('# operationId:foo'), 'API cell was not detected with ' + str(parser.kernelspec_operation_indicator))
+        self.assertTrue(parser.is_api_cell('#operationId: foo'), 'API cell was not detected with ' + str(parser.kernelspec_operation_indicator))
+        self.assertFalse(parser.is_api_cell('no'), 'API cell was detected')
+        self.assertFalse(parser.is_api_cell('# another comment'), 'API cell was detected')
+
+    def test_basic_is_api_response_cell(self):
+        """Parser should correctly identify ResponseInfo cells."""
+        parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=[{"source":'```\n{"swagger":"2.0", "paths": {"": {"post": {"operationId": "foo", "parameters": [{"name": "foo"}]}}}}\n```\n'}])
+        self.assertTrue(parser.is_api_response_cell('#ResponseInfo operationId:foo'), 'Response cell was not detected with ' + str(parser.kernelspec_operation_response_indicator))
+        self.assertTrue(parser.is_api_response_cell('# ResponseInfo operationId:foo'), 'Response cell was not detected with ' + str(parser.kernelspec_operation_response_indicator))
+        self.assertTrue(parser.is_api_response_cell('# ResponseInfo  operationId: foo'), 'Response cell was not detected with ' + str(parser.kernelspec_operation_response_indicator))
+        self.assertTrue(parser.is_api_response_cell('#ResponseInfo operationId: foo'), 'Response cell was not detected with ' + str(parser.kernelspec_operation_response_indicator))
+        self.assertFalse(parser.is_api_response_cell('# operationId: foo'), 'API cell was detected as a ResponseInfo cell ' + str(parser.kernelspec_operation_response_indicator))
+        self.assertFalse(parser.is_api_response_cell('no'), 'API cell was detected')
+
+    def test_endpoint_sort_default_strategy(self):
+        """Parser should sort duplicate endpoint paths."""
+        source_cells = [
+            {"source":'\n```\n{"swagger":"2.0","paths":{"":{"post":{"operationId":"postRoot","parameters":[{"name":"foo"}]}},"/hello":{"post":{"operationId":"postHello","parameters":[{"name":"foo"}]},"get":{"operationId":"getHello","parameters":[{"name":"foo"}]}},"/hello/world":{"put":{"operationId":"putWorld"}}}}\n```\n'},
+            {"source":'# operationId:putWorld'},
+            {"source":'# operationId:getHello'},
+            {"source":'# operationId:postHello'},
+            {"source":'# operationId:postRoot'},
+        ]
+        parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells = source_cells)
+        endpoints = parser.endpoints(cell['source'] for cell in source_cells)
+
+        expected_values = ['/hello/world', '/hello/:foo', '/:foo']
+        try:
+            for index in range(0, len(expected_values)):
+                endpoint, _ = endpoints[index]
+                self.assertEqual(expected_values[index], endpoint, 'Endpoint was not found in expected order')
+        except IndexError:
+            self.fail(endpoints)
+
+    def test_endpoint_sort_custom_strategy(self):
+        """Parser should sort duplicate endpoint paths using a custom sort
+        strategy.
+        """
+        source_cells = [
+            {"source":'```\n{"swagger": "2.0", "paths": {"/1": {"post": {"operationId": "post1"}},"/+": {"post": {"operationId": "postPlus"}},"/a": {"get": {"operationId": "getA"}}}}\n```\n'},
+            {"source":'# operationId: post1'},
+            {"source":'# operationId: postPlus'},
+            {"source":'# operationId: getA'},
+        ]
+
+        def custom_sort_fun(endpoint):
+            index = sys.maxsize
+            if endpoint.find('1') >= 0:
+                return 0
+            elif endpoint.find('a') >= 0:
+                return 1
+            else:
+                return 2
+
+        parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=source_cells)
+        endpoints = parser.endpoints((cell['source'] for cell in source_cells), custom_sort_fun)
+        print(str(endpoints))
+
+        expected_values = ['/+', '/a', '/1']
+        for index in range(0, len(expected_values)):
+            endpoint, _ = endpoints[index]
+            self.assertEqual(expected_values[index], endpoint, 'Endpoint was not found in expected order')
+
+    def test_get_cell_endpoint_and_verb(self):
+        """Parser should extract API endpoint and verb from cell annotations."""
+        parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=[{'source':'```\n{"swagger":"2.0", "paths": {"/foo": {"get": {"operationId": "getFoo"}}, "/bar/quo": {"post": {"operationId": "post_bar_Quo"}}}}\n```\n'}])
+        endpoint, verb = parser.get_cell_endpoint_and_verb('# operationId: getFoo')
+        self.assertEqual(endpoint, '/foo', 'Endpoint was not extracted correctly')
+        self.assertEqual(verb.lower(), 'get', 'Endpoint was not extracted correctly')
+        endpoint, verb = parser.get_cell_endpoint_and_verb('# operationId: post_bar_Quo')
+        self.assertEqual(endpoint, '/bar/quo', 'Endpoint was not extracted correctly')
+        self.assertEqual(verb.lower(), 'post', 'Endpoint was not extracted correctly')
+
+        endpoint, verb = parser.get_cell_endpoint_and_verb('some regular code')
+        self.assertEqual(endpoint, None, 'Endpoint was not extracted correctly (something was actually returned)')
+        self.assertEqual(verb, None, 'Endpoint was not extracted correctly (something was actually returned)')
+
+    def test_endpoint_concatenation(self):
+        """Parser should concatenate multiple cells with the same verb+path."""
+        cells = [
+            {"source":'```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putFoo","parameters": [{"name": "bar"}]},"post":{"operationId":"postFooBody"},"get": {"operationId":"getFoo","parameters": [{"name": "bar"}]}}}}\n```\n'},
+            {"source":'# operationId: postFooBody '},
+            {"source":'# unrelated comment '},
+            {"source":'# operationId: putFoo'},
+            {"source":'# operationId: puttFoo'},
+            {"source":'# operationId: getFoo'},
+            {"source":'# operationId: putFoo'}
+        ]
+        parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=cells)
+        endpoints = parser.endpoints(cell['source'] for cell in cells)
+        self.assertEqual(len(endpoints), 2, endpoints)
+        # for ease of testing
+        endpoints = dict(endpoints)
+        self.assertEqual(len(endpoints['/foo']), 1)
+        self.assertEqual(len(endpoints['/foo/:bar']), 2)
+        self.assertEqual(endpoints['/foo']['post'], '# operationId: postFooBody \n')
+        self.assertEqual(endpoints['/foo/:bar']['get'], '# operationId: getFoo\n')
+        self.assertEqual(endpoints['/foo/:bar']['put'], '# operationId: putFoo\n# operationId: putFoo\n')
+
+    def test_endpoint_response_concatenation(self):
+        """Parser should concatenate multiple response cells with the same
+        verb+path.
+        """
+        source_cells = [
+            {"source":'```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'},
+            {"source":'# ResponseInfo operationId: get'},
+            {"source":'# ResponseInfo operationId: postbar '},
+            {"source":'# ResponseInfo operationId: putbar'},
+            {"source":'# ResponseInfo operationId: puttbar'},
+            {"source":'ignored'},
+            {"source":'# ResponseInfo operationId: putbar '}
+        ]
+        parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=source_cells)
+        endpoints = parser.endpoint_responses(cell['source'] for cell in source_cells)
+        self.assertEqual(len(endpoints), 2)
+        # for ease of testing
+        endpoints = dict(endpoints)
+        self.assertEqual(len(endpoints['/foo']), 1)
+        self.assertEqual(len(endpoints['/foo/:bar']), 2)
+        self.assertEqual(endpoints['/foo']['post'], '# ResponseInfo operationId: postbar \n')
+        self.assertEqual(endpoints['/foo/:bar']['put'], '# ResponseInfo operationId: putbar\n# ResponseInfo operationId: putbar \n')
+        self.assertEqual(endpoints['/foo/:bar']['get'], '# ResponseInfo operationId: get\n')
+
+    def test_undeclared_operations(self):
+        """Parser should warn about operations that aren't documented in the
+        swagger cell
+        """
+        source_cells = [
+            {"source":'```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'},
+            {"source":'# operationId: get'},
+            {"source":'# operationId: postbar '},
+            {"source":'# operationId: putbar'},
+            {"source":'# operationId: extraOperation'},
+        ]
+        with self.assertLogs(level='WARNING') as warnings:
+            parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=source_cells)
+            for output in warnings.output:
+                self.assertRegex(output, 'extraOperation')
+
+    def test_unreferenced_operations(self):
+        """Parser should warn about documented operations that aren't referenced
+        in a cell
+        """
+        source_cells = [
+            {"source":'```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'},
+            {"source":'# operationId: get'},
+            {"source":'# operationId: putbar'},
+            {"source":'# operationId: putbar '}
+        ]
+        with self.assertLogs(level='WARNING') as warnings:
+            parser = SwaggerCellParser(kernelspec='some_unknown_kernel', notebook_cells=source_cells)
+            for output in warnings.output:
+                self.assertRegex(output, 'postbar')


### PR DESCRIPTION
Allow notebook-http to support alternate ways of marking cells as API endpoints. Add one that supports Swagger, and uses the same to help generate a more detailed API spec.

(c) Copyright IBM Corp. 2016