### PR TITLE
Option to serve static files under /public

### DIFF
--- a/kernel_gateway/tests/resources/public/index.html
+++ b/kernel_gateway/tests/resources/public/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Hello world!</title>
+    </head>
+    <body>
+        <h1>Hello world!</h1>
+    </body>
+</html>

--- a/kernel_gateway/tests/test_notebook_http.py
+++ b/kernel_gateway/tests/test_notebook_http.py
@@ -190,14 +190,26 @@ class TestDefaults(TestGatewayAppBase):
     @gen_test
     def test_blocked_download_notebook_source(self):
         """Notebook source should not exist under the path /_api/source when
-        `allow_notebook` download is False or not configured.
+        `allow_notebook_download` is False or not configured.
         """
         response = yield self.http_client.fetch(
             self.get_url('/_api/source'),
             method='GET',
             raise_error=False
         )
-        self.assertEqual(response.code, 404, "/_api/source did not block as allow_notebook_download is false")
+        self.assertEqual(response.code, 404, "/_api/source found when allow_notebook_download is false")
+
+    @gen_test
+    def test_blocked_public(self):
+        """Public static assets should not exist under the path /public when
+        `static_path` is False or not configured.
+        """
+        response = yield self.http_client.fetch(
+            self.get_url('/public'),
+            method='GET',
+            raise_error=False
+        )
+        self.assertEqual(response.code, 404, "/public found when static_path is false")
 
     @gen_test
     def test_api_returns_execute_result(self):
@@ -232,6 +244,30 @@ class TestDefaults(TestGatewayAppBase):
         self.assertEqual(response.code, 200, 'GET endpoint did not return 200.')
         self.assertEqual(response.body, b'KERNEL_GATEWAY is 1\n', 'Unexpected body in response to GET.')
 
+class TestPublicStatic(TestGatewayAppBase):
+    """Tests gateway behavior when public static assets are enabled."""
+    def setup_app(self):
+        """Sets the notebook-http mode and points to a local test notebook as
+        the basis for the API. 
+        """
+        self.app.api = 'kernel_gateway.notebook_http'
+        self.app.seed_uri = os.path.join(RESOURCES,
+                                         'kernel_api{}.ipynb'.format(sys.version_info.major))
+
+    def setup_configurables(self):
+        """Configures the static path at the root of the resources/public folder."""
+        self.app.personality.static_path = os.path.join(RESOURCES, 'public')
+
+    @gen_test
+    def test_get_public(self):
+        """index.html should exist under `/public/index.html`."""
+        response = yield self.http_client.fetch(
+            self.get_url('/public/index.html'),
+            method='GET',
+            raise_error=False
+        )
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers.get('Content-Type'), 'text/html')
 
 class TestSourceDownload(TestGatewayAppBase):
     """Tests gateway behavior when notebook download is allowed."""


### PR DESCRIPTION
For notebook-http mode only. Useful in cases where the notebook API wants
to refer to public static files without bothering the kernel to read them
and serve them itself (e.g., generated images).