### PR TITLE
Issue 187: dev image build failure from missing dependency

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,11 @@
 # Distributed under the terms of the Modified BSD License.
 
 FROM jupyter/pyspark-notebook:8015c88c4b11
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends enchant
+USER $NB_USER
+
 RUN conda install -y nose && \
     conda install -y -n python2 nose
 


### PR DESCRIPTION
    Adds the enchant package to the dev/test image
(c) Copyright IBM Corp. 2016