### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## 1.0.0 (2016-07-15)
 
-* Introduce an [API for developing mode plug-ins](http://jupyter-kernel-gateway.readthedocs.io/en/latest/plug-in.html)
+* Introduce an [API for developing mode plug-ins](https://jupyter-kernel-gateway.readthedocs.io/en/latest/plug-in.html)
 * Separate `jupyter-websocket` and `notebook-http` modes into  plug-in packages
 * Move mode specific command line options into their respective packages (see `--help-all`)
 * Report times with respect to UTC in `/_api/activity` responses

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/jupyter_kernel_gateway.svg)](https://badge.fury.io/py/jupyter_kernel_gateway) 
 [![Build Status](https://travis-ci.org/jupyter-incubator/dashboards.svg?branch=master)](https://travis-ci.org/jupyter/kernel_gateway)
 [![Code Health](https://landscape.io/github/jupyter/kernel_gateway/master/landscape.svg?style=flat)](https://landscape.io/github/jupyter/kernel_gateway/master)
-[![Documentation Status](http://readthedocs.org/projects/jupyter-kernel-gateway/badge/?version=latest)](http://jupyter-kernel-gateway.readthedocs.org/en/latest/?badge=latest)
+[![Documentation Status](http://readthedocs.org/projects/jupyter-kernel-gateway/badge/?version=latest)](https://jupyter-kernel-gateway.readthedocs.io/en/latest/?badge=latest)
 
 ## Overview
 
@@ -12,7 +12,7 @@ The kernel gateway is a web server that supports different mechanisms for spawni
 communicating with Jupyter kernels, such as:
 
 * A Jupyter Notebook server-compatible HTTP API used for requesting kernels
-  and talking the [Jupyter kernel protocol](https://jupyter-client.readthedocs.org/en/latest/messaging.html)
+  and talking the [Jupyter kernel protocol](https://jupyter-client.readthedocs.io/en/latest/messaging.html)
   with the kernels over Websockets
 * A HTTP API defined by annotated notebook cells that maps HTTP verbs and
   resources to code to execute on a kernel
@@ -23,17 +23,17 @@ The server launches kernels in its local process/filesystem space. It can be con
 
 * Attach a local Jupyter Notebook server to a compute cluster in the cloud running near big data (e.g., interactive gateway to Spark)
 * Enable a new breed of non-notebook web clients to provision and use kernels (e.g., web dashboards using [jupyter-js-services](https://github.com/jupyter/jupyter-js-services))
-* Create microservices from notebooks using the Kernel Gateway [`notebook-http` mode](http://jupyter-kernel-gateway.readthedocs.org/en/latest/http-mode.html)
+* Create microservices from notebooks using the Kernel Gateway [`notebook-http` mode](https://jupyter-kernel-gateway.readthedocs.io/en/latest/http-mode.html)
 
 ### Features
 
-See the [Features page](https://jupyter-kernel-gateway.readthedocs.org/en/latest/features.html) in the 
+See the [Features page](https://jupyter-kernel-gateway.readthedocs.io/en/latest/features.html) in the 
 documentation for a list of the Jupyter Kernel Gateway features.
 
 ## Installation
 
 Detailed installation instructions are located in the 
-[Getting Started page](https://jupyter-kernel-gateway.readthedocs.org/en/latest/getting-started.html)
+[Getting Started page](https://jupyter-kernel-gateway.readthedocs.io/en/latest/getting-started.html)
 of the project docs. Here's a quick start using `pip`:
 
 ```bash
@@ -49,4 +49,4 @@ jupyter kernelgateway
 
 ## Contributing
 
-The [Development page](https://jupyter-kernel-gateway.readthedocs.org/en/latest/devinstall.html) includes information about setting up a development environment and typical developer tasks.
+The [Development page](https://jupyter-kernel-gateway.readthedocs.io/en/latest/devinstall.html) includes information about setting up a development environment and typical developer tasks.

--- a/docs/source/http-mode.md
+++ b/docs/source/http-mode.md
@@ -64,7 +64,7 @@ The response from an annotated cell may be set in one of two ways:
 
 The first method is preferred because it is explicit: a cell writes to stdout using the appropriate language statement or function (e.g. Python `print`, Scala `println`, R `print`, etc.). The kernel gateway collects all bytes from kernel stdout and returns the entire byte string verbatim as the response body.
 
-The second approach is used if nothing appears on stdout. This method is dependent upon language semantics, kernel implementation, and library usage. The response body will be the `content.data` structure in the Jupyter [`execute_result`](http://jupyter-client.readthedocs.org/en/latest/messaging.html#id4) message.
+The second approach is used if nothing appears on stdout. This method is dependent upon language semantics, kernel implementation, and library usage. The response body will be the `content.data` structure in the Jupyter [`execute_result`](https://jupyter-client.readthedocs.io/en/latest/messaging.html#id4) message.
 
 In both cases, the response defaults to status `200 OK` and `Content-Type: text/plain` if cell execution completes without error. If an error occurs, the status is `500 Internal Server Error`. If the HTTP request method is not one supported at the given path, the status is `405 Not Supported`. If you wish to return custom status or headers, see the next section.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Jupyter Kernel Gateway is a web server that supports different mechanisms for
 spawning and communicating with Jupyter kernels, such as:
 
 * A Jupyter Notebook server-compatible HTTP API used for requesting kernels
-  and talking the `Jupyter kernel protocol <https://jupyter-client.readthedocs.org/en/latest/messaging.html>`_
+  and talking the `Jupyter kernel protocol <https://jupyter-client.readthedocs.io/en/latest/messaging.html>`_
   with the kernels over Websockets
 * A HTTP API defined by annotated notebook cells that maps HTTP verbs and
   resources to code to execute on a kernel

--- a/docs/source/summary-changes.md
+++ b/docs/source/summary-changes.md
@@ -20,7 +20,7 @@ See `git log` for a more detailed summary of changes.
 
 ### 1.0.0 (2016-07-15)
 
-* Introduce an [API for developing mode plug-ins](http://jupyter-kernel-gateway.readthedocs.io/en/latest/plug-in.html)
+* Introduce an [API for developing mode plug-ins](https://jupyter-kernel-gateway.readthedocs.io/en/latest/plug-in.html)
 * Separate `jupyter-websocket` and `notebook-http` modes into  plug-in packages
 * Move mode specific command line options into their respective packages (see `--help-all`)
 * Report times with respect to UTC in `/_api/activity` responses

--- a/docs/source/websocket-mode.md
+++ b/docs/source/websocket-mode.md
@@ -11,6 +11,6 @@ The HTTP API consists of kernel, session, monitoring, and metadata resources. Al
 
 ### Websocket Resources
 
-The `/api/kernels/{kernel_id}/channels` resource multiplexes the [Jupyter kernel messaging protocol](http://jupyter-client.readthedocs.org/en/latest/messaging.html) over a single Websocket connection.
+The `/api/kernels/{kernel_id}/channels` resource multiplexes the [Jupyter kernel messaging protocol](https://jupyter-client.readthedocs.io/en/latest/messaging.html) over a single Websocket connection.
 
 See the [NodeJS](https://github.com/jupyter/kernel_gateway_demos/tree/master/node_client_example) and [Python](https://github.com/jupyter/kernel_gateway_demos/tree/master/python_client_example) client demos for two simple examples of using these resources to send code to kernels for interactive evaluation.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ Jupyter Kernel Gateway is a web server that supports different mechanisms for
 spawning and communicating with Jupyter kernels, such as:
 
 * A Jupyter Notebook server-compatible HTTP API used for requesting kernels
-  and talking the `Jupyter kernel protocol <https://jupyter-client.readthedocs.org/en/latest/messaging.html>`_
+  and talking the `Jupyter kernel protocol <https://jupyter-client.readthedocs.io/en/latest/messaging.html>`_
   with the kernels over Websockets
 * A HTTP API defined by annotated notebook cells that maps HTTP verbs and
   resources to code to execute on a kernel


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.