### PR TITLE
Fix language comment syntax selection

### DIFF
--- a/kernel_gateway/notebook_http/cell/parser.py
+++ b/kernel_gateway/notebook_http/cell/parser.py
@@ -53,33 +53,23 @@ class APICellParser(LoggingConfigurable):
 
     Parameters
     ----------
-    kernelspec
-        Name of the kernelspec in the notebook to be parsed
+    comment_prefix
+        Token indicating a comment in the notebook language
 
     Attributes
     ----------
-    kernelspec_comment_mapping : dict
-        Maps kernelspec names to language comment syntax
     api_indicator : str
         Regex pattern for API annotations
     api_response_indicator : str
         Regex pattern for API response metadata annotations
     """
-    kernelspec_comment_mapping = {
-        None:'#',
-        'scala':'//'
-    }
     api_indicator = r'{}\s+(GET|PUT|POST|DELETE)\s+(\/.*)+'
     api_response_indicator = r'{}\s+ResponseInfo\s+(GET|PUT|POST|DELETE)\s+(\/.*)+'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, comment_prefix, *args, **kwargs):
         super(APICellParser, self).__init__(*args, **kwargs)
-        try:
-            prefix = self.kernelspec_comment_mapping[self.kernelspec]
-        except KeyError:
-            prefix = self.kernelspec_comment_mapping[None]
-        self.kernelspec_api_indicator = re.compile(self.api_indicator.format(prefix))
-        self.kernelspec_api_response_indicator = re.compile(self.api_response_indicator.format(prefix))
+        self.kernelspec_api_indicator = re.compile(self.api_indicator.format(comment_prefix))
+        self.kernelspec_api_response_indicator = re.compile(self.api_response_indicator.format(comment_prefix))
 
     def is_api_cell(self, cell_source):
         """Gets if the cell source is annotated as an API endpoint.
@@ -151,8 +141,8 @@ class APICellParser(LoggingConfigurable):
         the eventual response output.
         """
         return {
-            'responses' : {
-                200 : { 'description': 'Success'}
+            'responses': {
+                200: {'description': 'Success'}
             }
         }
 
@@ -221,7 +211,7 @@ class APICellParser(LoggingConfigurable):
         dictionary
             Dictionary with a root "swagger" property
         """
-        return { 'swagger' : '2.0', 'paths' : {}, 'info' : {'version' : '0.0.0'} }
+        return {'swagger': '2.0', 'paths': {}, 'info': {'version': '0.0.0'}}
 
 def create_parser(*args, **kwargs):
     return APICellParser(*args, **kwargs)

--- a/kernel_gateway/notebook_http/swagger/parser.py
+++ b/kernel_gateway/notebook_http/swagger/parser.py
@@ -48,35 +48,28 @@ class SwaggerCellParser(LoggingConfigurable):
     * `ID` is an operation's ID as documented in a Swagger comment block
     * `operationId` is a literal token.
 
+    Parameters
+    ----------
+    comment_prefix
+        Token indicating a comment in the notebook language
+
     Attributes
     ----------
-    kernelspec
-        Name of the kernelspec in the notebook to be parsed
-    kernelspec_comment_mapping : dict
-        Maps kernelspec names to language comment syntax
-    notebook_cells : list
+   notebook_cells : list
         The cells from the target notebook, one of which must contain a Swagger spec in a commented block
     operation_indicator : str
         Regex pattern for API annotations
     operation_response_indicator : str
         Regex pattern for API response metadata annotations
     """
-    kernelspec_comment_mapping = {
-        None:'#',
-        'scala':'//'
-    }
     operation_indicator = r'{}\s*operationId:\s*(.*)'
     operation_response_indicator = r'{}\s*ResponseInfo\s+operationId:\s*(.*)'
     notebook_cells = []
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, comment_prefix, *args, **kwargs):
         super(SwaggerCellParser, self).__init__(*args, **kwargs)
-        try:
-            prefix = self.kernelspec_comment_mapping[self.kernelspec]
-        except KeyError:
-            prefix = self.kernelspec_comment_mapping[None]
-        self.kernelspec_operation_indicator = re.compile(self.operation_indicator.format(prefix))
-        self.kernelspec_operation_response_indicator = re.compile(self.operation_response_indicator.format(prefix))
+        self.kernelspec_operation_indicator = re.compile(self.operation_indicator.format(comment_prefix))
+        self.kernelspec_operation_response_indicator = re.compile(self.operation_response_indicator.format(comment_prefix))
         self.swagger = dict()
         operationIdsFound = []
         operationIdsDeclared = []
@@ -277,8 +270,8 @@ class SwaggerCellParser(LoggingConfigurable):
                     return self.swagger['paths'][endpoint][verb]
         # mismatched operationId? return a default
         return {
-            'responses' : {
-                200 : { 'description': 'Success'}
+            'responses': {
+                200: {'description': 'Success'}
             }
         }
 
@@ -291,7 +284,7 @@ class SwaggerCellParser(LoggingConfigurable):
         """
         if self.swagger is not None:
             return self.swagger
-        return { 'swagger' : '2.0', 'paths' : {}, 'info' : {'version' : '0.0.0', 'title' : 'Default Title'} };
+        return {'swagger': '2.0', 'paths': {}, 'info': {'version': '0.0.0', 'title': 'Default Title'}}
 
 def create_parser(*args, **kwargs):
     return SwaggerCellParser(*args, **kwargs)

--- a/kernel_gateway/tests/notebook_http/swagger/test_builders.py
+++ b/kernel_gateway/tests/notebook_http/swagger/test_builders.py
@@ -14,7 +14,7 @@ class TestSwaggerBuilders(unittest.TestCase):
     def test_add_title_adds_title_to_spec(self):
         """Builder should store an API title."""
         expected = 'Some New Title'
-        builder = SwaggerSpecBuilder(APICellParser(kernelspec='some_spec'))
+        builder = SwaggerSpecBuilder(APICellParser(comment_prefix='#'))
         builder.set_default_title(expected)
         result = builder.build()
         self.assertEqual(result['info']['title'] ,expected,'Title was not set to new value')
@@ -28,7 +28,7 @@ class TestSwaggerBuilders(unittest.TestCase):
                 }
             }
         }
-        builder = SwaggerSpecBuilder(APICellParser(kernelspec='some_spec'))
+        builder = SwaggerSpecBuilder(APICellParser(comment_prefix='#'))
         builder.add_cell('# GET /some/resource')
         result = builder.build()
         self.assertEqual(result['paths']['/some/resource'] ,expected,'Title was not set to new value')
@@ -73,7 +73,7 @@ class TestSwaggerBuilders(unittest.TestCase):
             }
         }
         '''
-        builder = SwaggerSpecBuilder(SwaggerCellParser(kernelspec='some_spec', notebook_cells = [{"source":expected}]))
+        builder = SwaggerSpecBuilder(SwaggerCellParser(comment_prefix='#', notebook_cells = [{"source":expected}]))
         builder.add_cell(expected)
         result = builder.build()
         self.maxDiff = None
@@ -90,7 +90,7 @@ class TestSwaggerBuilders(unittest.TestCase):
 
     def test_add_undocumented_cell_does_not_add_non_api_cell_to_spec(self):
         """Builder should store ignore non-API cells."""
-        builder = SwaggerSpecBuilder(SwaggerCellParser(kernelspec='some_spec'))
+        builder = SwaggerSpecBuilder(SwaggerCellParser(comment_prefix='#'))
         builder.add_cell('regular code cell')
         builder.add_cell('# regular commented cell')
         result = builder.build()

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -62,7 +62,7 @@ class TestGatewayAppConfig(unittest.TestCase):
 
 class TestGatewayAppBase(AsyncHTTPTestCase, LogTrapTestCase):
     """Base class for integration style tests using HTTP/Websockets against an
-    instance of the gateway app..
+    instance of the gateway app.
 
     Attributes
     ----------


### PR DESCRIPTION
Use metadata.language_info.name property instead of metadata.kernelspec.name. Also remove code duplication between cell and swagger parsers.

Fixes #195