### PR TITLE
Websocket auth with token as query param

### DIFF
--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -69,8 +69,8 @@ make docs
 After modifying any of the APIs in `jupyter-websocket` mode, you must update the project's Swagger API specification.
 
 1. Load the current
-[swagger.yaml](https://github.com/jupyter/kernel_gateway/blob/master/kernel_gateway/services/api/swagger.yaml) file into the [Swagger editor](http://editor.swagger.io/#/).
+[swagger.yaml](https://github.com/jupyter/kernel_gateway/blob/master/kernel_gateway/jupyter_websocket/swagger.yaml) file into the [Swagger editor](http://editor.swagger.io/#/).
 2. Make your changes.
 3. Export both the `swagger.json` and `swagger.yaml` files.
-4. Place the files in `kernel_gateway/services/api`.
+4. Place the files in `kernel_gateway/jupyter_websocket`.
 5. Add, commit, and PR the changes.

--- a/kernel_gateway/jupyter_websocket/swagger.json
+++ b/kernel_gateway/jupyter_websocket/swagger.json
@@ -34,11 +34,17 @@
         }
     },
     "securityDefinitions": {
-        "token": {
+        "tokenHeader": {
             "type": "apiKey",
             "name": "Authorization",
             "in": "header",
-            "description": "The authorization token to verify authorization. This is only needed when `KernelGatewayApp.auth_token` is set. This should take the form of `token {value}` where `{value}` is the value of the token."
+            "description": "The authorization token to verify authorization. This is only needed when `KernelGatewayApp.auth_token` is set. This should take the form of `token {value}` where `{value}` is the value of the token. Alternatively, the token can be passed as a query parameter."
+        },
+        "tokenParam": {
+            "type": "apiKey",
+            "name": "token",
+            "in": "query",
+            "description": "The authorization token to verify authorization. This is only needed when `KernelGatewayApp.auth_token` is set. This should take the form of `token={value}` where `{value}` is the value of the token. Alternatively, the token can be passed as a header."
         }
     },
     "paths": {
@@ -91,7 +97,10 @@
             "get": {
                 "security": [
                     {
-                        "token": []
+                        "tokenHeader": []
+                    },
+                    {
+                        "tokenParam": []
                     }
                 ],
                 "summary": "Get kernel specs",

--- a/kernel_gateway/jupyter_websocket/swagger.yaml
+++ b/kernel_gateway/jupyter_websocket/swagger.yaml
@@ -29,13 +29,20 @@ parameters:
     format: uuid
     
 securityDefinitions:
-  token:
+  tokenHeader:
     type: apiKey
     name: Authorization
     in: header
     description: The authorization token to verify authorization. This is only
       needed when `KernelGatewayApp.auth_token` is set. This should take the 
-      form of `token {value}` where `{value}` is the value of the token.
+      form of `token {value}` where `{value}` is the value of the token. Alternatively, the token can be passed as a query parameter.
+  tokenParam:
+    type: apiKey
+    name: token
+    in: query
+    description: The authorization token to verify authorization. This is only
+      needed when `KernelGatewayApp.auth_token` is set. This should take the 
+      form of `token={value}` where `{value}` is the value of the token. Alternatively, the token can be passed as a header.
 
 paths:
   /api:
@@ -69,7 +76,8 @@ paths:
   /api/kernelspecs:
     get:
       security: 
-        - token: []
+        - tokenHeader: []
+        - tokenParam: []
       summary: Get kernel specs
       tags:
         - kernelspecs

--- a/kernel_gateway/mixins.py
+++ b/kernel_gateway/mixins.py
@@ -59,7 +59,7 @@ class TokenAuthorizationMixin(object):
         server_token = self.settings.get('kg_auth_token')
         if server_token:
             client_token = self.get_argument('token', None)
-            if client_token == None:
+            if client_token is None:
                 client_token = self.request.headers.get('Authorization')
                 if client_token and client_token.startswith(self.header_prefix):
                     client_token = client_token[self.header_prefix_len:]

--- a/kernel_gateway/mixins.py
+++ b/kernel_gateway/mixins.py
@@ -39,6 +39,9 @@ class TokenAuthorizationMixin(object):
     """Mixes token auth into tornado.web.RequestHandlers and
     tornado.websocket.WebsocketHandlers.
     """
+    header_prefix = "token "
+    header_prefix_len = len(header_prefix)
+
     def prepare(self):
         """Ensures the correct auth token is present, either as a parameter
         `token=<value>` or as a header `Authorization: token <value>`.
@@ -55,11 +58,11 @@ class TokenAuthorizationMixin(object):
         """
         server_token = self.settings.get('kg_auth_token')
         if server_token:
-            client_token = self.get_argument('token', '')
-            if client_token == '':
+            client_token = self.get_argument('token', None)
+            if client_token == None:
                 client_token = self.request.headers.get('Authorization')
-                if client_token and client_token.startswith('token '):
-                    client_token = client_token[len('token '):]
+                if client_token and client_token.startswith(self.header_prefix):
+                    client_token = client_token[self.header_prefix_len:]
                 else:
                     client_token = None
             if client_token != server_token:

--- a/kernel_gateway/tests/test_mixins.py
+++ b/kernel_gateway/tests/test_mixins.py
@@ -4,7 +4,13 @@
 
 import json
 import unittest
-from unittest.mock import Mock, MagicMock
+
+try:
+    from unittest.mock import Mock, MagicMock
+except ImportError:
+    # Python 2.7: use backport
+    from mock import Mock, MagicMock
+
 from tornado import web
 from kernel_gateway.mixins import TokenAuthorizationMixin, JSONErrorsMixin
 


### PR DESCRIPTION
Fixes #233 for version 2.0:
- unit tests for auth mixin
- code changes to auth mixin
- updated swagger
- fixed swagger link in docs