### PR TITLE
Fix #243: Support configured headers for OPTIONS requests

### DIFF
--- a/kernel_gateway/mixins.py
+++ b/kernel_gateway/mixins.py
@@ -35,6 +35,14 @@ class CORSMixin(object):
         # Don't set CSP: we're not serving frontend media types only JSON
         self.clear_header('Content-Security-Policy')
 
+    def options(self):
+        """Override the notebook implementation to return the headers
+        configured in `set_default_headers instead of the hardcoded set
+        supported by the handler base class in the notebook project.
+        """
+        self.finish()
+
+
 class TokenAuthorizationMixin(object):
     """Mixes token auth into tornado.web.RequestHandlers and
     tornado.websocket.WebsocketHandlers.
@@ -68,6 +76,7 @@ class TokenAuthorizationMixin(object):
             if client_token != server_token:
                 return self.send_error(401)
         return super(TokenAuthorizationMixin, self).prepare()
+
 
 class JSONErrorsMixin(object):
     """Mixes `write_error` into tornado.web.RequestHandlers to respond with

--- a/kernel_gateway/tests/test_jupyter_websocket.py
+++ b/kernel_gateway/tests/test_jupyter_websocket.py
@@ -274,6 +274,21 @@ class TestDefaults(TestJupyterWebsocket):
         self.assertEqual(response.headers.get('Content-Security-Policy'), None)
 
     @gen_test
+    def test_cors_options_headers(self):
+        """All preflight OPTIONS requests should return configured headers."""
+        app = self.get_app()
+        app.settings['kg_allow_headers'] = 'X-XSRFToken'
+        app.settings['kg_allow_methods'] = 'GET,POST,OPTIONS'
+
+        response = yield self.http_client.fetch(
+            self.get_url('/api/kernelspecs'),
+            method='OPTIONS'
+        )
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers['Access-Control-Allow-Methods'], 'GET,POST,OPTIONS')
+        self.assertEqual(response.headers['Access-Control-Allow-Headers'], 'X-XSRFToken')
+
+    @gen_test
     def test_max_kernels(self):
         """Number of kernels should be limited."""
         app = self.get_app()


### PR DESCRIPTION
* Override options in the CORSMixin
* Add a test case