### PR TITLE
Fix to make IPerl notebooks running in notebook-http mode

### DIFF
--- a/kernel_gateway/notebook_http/__init__.py
+++ b/kernel_gateway/notebook_http/__init__.py
@@ -122,7 +122,8 @@ class NotebookHTTPPersonality(LoggingConfigurable):
             handler_args = { 'sources' : verb_source_map,
                 'response_sources' : response_source_map,
                 'kernel_pool' : self.kernel_pool,
-                'kernel_name' : self.parent.kernel_manager.seed_kernelspec
+                'kernel_name' : self.parent.kernel_manager.seed_kernelspec,
+                'kernel_language' : getattr(self.parent.kernel_spec_manager.get_kernel_spec(self.parent.kernel_manager.seed_kernelspec), 'language', 'no_spec')
             }
             handlers.append((parameterized_path, NotebookAPIHandler, handler_args))
 

--- a/kernel_gateway/notebook_http/__init__.py
+++ b/kernel_gateway/notebook_http/__init__.py
@@ -70,6 +70,7 @@ class NotebookHTTPPersonality(LoggingConfigurable):
         self.api_parser = func(parent=self, log=self.log,
                                comment_prefix=prefix,
                                notebook_cells=self.parent.seed_notebook.cells)
+        self.kernel_language = lang
 
     def init_configurables(self):
         """Create a managed kernel pool"""
@@ -123,7 +124,7 @@ class NotebookHTTPPersonality(LoggingConfigurable):
                 'response_sources' : response_source_map,
                 'kernel_pool' : self.kernel_pool,
                 'kernel_name' : self.parent.kernel_manager.seed_kernelspec,
-                'kernel_language' : getattr(self.parent.kernel_spec_manager.get_kernel_spec(self.parent.kernel_manager.seed_kernelspec), 'language', 'no_spec')
+                'kernel_language' : self.kernel_language or 'no_spec'
             }
             handlers.append((parameterized_path, NotebookAPIHandler, handler_args))
 

--- a/kernel_gateway/notebook_http/__init__.py
+++ b/kernel_gateway/notebook_http/__init__.py
@@ -124,7 +124,7 @@ class NotebookHTTPPersonality(LoggingConfigurable):
                 'response_sources' : response_source_map,
                 'kernel_pool' : self.kernel_pool,
                 'kernel_name' : self.parent.kernel_manager.seed_kernelspec,
-                'kernel_language' : self.kernel_language or 'no_spec'
+                'kernel_language' : self.kernel_language or ''
             }
             handlers.append((parameterized_path, NotebookAPIHandler, handler_args))
 

--- a/kernel_gateway/notebook_http/handlers.py
+++ b/kernel_gateway/notebook_http/handlers.py
@@ -184,7 +184,7 @@ class NotebookAPIHandler(TokenAuthorizationMixin,
                 'headers' : headers_to_dict(self.request.headers)
             })
             # Turn the request string into a valid code string
-            request_code = format_request(request)
+            request_code = format_request(request, self.kernel_name)
 
             # Run the request and source code and yield until there's a result
             access_log.debug('Request code for notebook cell is: {}'.format(request_code))

--- a/kernel_gateway/notebook_http/handlers.py
+++ b/kernel_gateway/notebook_http/handlers.py
@@ -33,8 +33,7 @@ class NotebookAPIHandler(TokenAuthorizationMixin,
     kernel_pool
         Instance of services.kernels.ManagedKernelPool
     kernel_name
-        Kernel spec name used to launch the kernel pool. Identifies the
-        language of the source code cells.
+        Kernel spec name used to launch the kernel pool
     kernel_language
         Kernel spec language used to make language specific operations
 

--- a/kernel_gateway/notebook_http/handlers.py
+++ b/kernel_gateway/notebook_http/handlers.py
@@ -46,7 +46,7 @@ class NotebookAPIHandler(TokenAuthorizationMixin,
     services.cell.parser.APICellParser for detail about how the source cells
     are identified, parsed, and associated with HTTP verbs and paths.
     """
-    def initialize(self, sources, response_sources, kernel_pool, kernel_name, kernel_language='no_spec'):
+    def initialize(self, sources, response_sources, kernel_pool, kernel_name, kernel_language=''):
         self.kernel_pool = kernel_pool
         self.sources = sources
         self.kernel_name = kernel_name

--- a/kernel_gateway/notebook_http/handlers.py
+++ b/kernel_gateway/notebook_http/handlers.py
@@ -35,6 +35,8 @@ class NotebookAPIHandler(TokenAuthorizationMixin,
     kernel_name
         Kernel spec name used to launch the kernel pool. Identifies the
         language of the source code cells.
+    kernel_language
+        Kernel spec language used to make language specific operations
 
     Attributes
     ----------
@@ -45,11 +47,12 @@ class NotebookAPIHandler(TokenAuthorizationMixin,
     services.cell.parser.APICellParser for detail about how the source cells
     are identified, parsed, and associated with HTTP verbs and paths.
     """
-    def initialize(self, sources, response_sources, kernel_pool, kernel_name):
+    def initialize(self, sources, response_sources, kernel_pool, kernel_name, kernel_language='no_spec'):
         self.kernel_pool = kernel_pool
         self.sources = sources
         self.kernel_name = kernel_name
         self.response_sources = response_sources
+        self.kernel_language = kernel_language
 
     def finish_future(self, future, result_accumulator):
         """Resolves the promise to respond to a HTTP request handled by a
@@ -184,7 +187,7 @@ class NotebookAPIHandler(TokenAuthorizationMixin,
                 'headers' : headers_to_dict(self.request.headers)
             })
             # Turn the request string into a valid code string
-            request_code = format_request(request, self.kernel_name)
+            request_code = format_request(request, self.kernel_language)
 
             # Run the request and source code and yield until there's a result
             access_log.debug('Request code for notebook cell is: {}'.format(request_code))

--- a/kernel_gateway/notebook_http/request_utils.py
+++ b/kernel_gateway/notebook_http/request_utils.py
@@ -12,9 +12,9 @@ MULTIPART_FORM_DATA = 'multipart/form-data'
 APPLICATION_JSON = 'application/json'
 TEXT_PLAIN = 'text/plain'
 
-def format_request(bundle, kernel_name):
+def format_request(bundle, kernel_language='no_spec'):
     """Creates an assignment statement of bundle JSON-encoded to a variable
-    named `REQUEST`.
+    named `REQUEST` by default or kernel_language specific.
 
     Returns
     -------
@@ -22,7 +22,7 @@ def format_request(bundle, kernel_name):
         `REQUEST = "<json-encoded expression>"`
     """
     bundle = json.dumps(bundle)
-    if kernel_name == 'iperl':
+    if kernel_language.lower() == 'perl':
         statement = "my $REQUEST = {}".format(bundle)
     else:
         statement = "REQUEST = {}".format(bundle)

--- a/kernel_gateway/notebook_http/request_utils.py
+++ b/kernel_gateway/notebook_http/request_utils.py
@@ -12,7 +12,7 @@ MULTIPART_FORM_DATA = 'multipart/form-data'
 APPLICATION_JSON = 'application/json'
 TEXT_PLAIN = 'text/plain'
 
-def format_request(bundle):
+def format_request(bundle, kernel_name):
     """Creates an assignment statement of bundle JSON-encoded to a variable
     named `REQUEST`.
 
@@ -22,7 +22,10 @@ def format_request(bundle):
         `REQUEST = "<json-encoded expression>"`
     """
     bundle = json.dumps(bundle)
-    statement = "REQUEST = {}".format(bundle)
+    if kernel_name == 'iperl':
+        statement = "my $REQUEST = {}".format(bundle)
+    else:
+        statement = "REQUEST = {}".format(bundle)
     return statement
 
 def parameterize_path(path):

--- a/kernel_gateway/notebook_http/request_utils.py
+++ b/kernel_gateway/notebook_http/request_utils.py
@@ -12,7 +12,7 @@ MULTIPART_FORM_DATA = 'multipart/form-data'
 APPLICATION_JSON = 'application/json'
 TEXT_PLAIN = 'text/plain'
 
-def format_request(bundle, kernel_language='no_spec'):
+def format_request(bundle, kernel_language=''):
     """Creates an assignment statement of bundle JSON-encoded to a variable
     named `REQUEST` by default or kernel_language specific.
 

--- a/kernel_gateway/notebook_http/request_utils.py
+++ b/kernel_gateway/notebook_http/request_utils.py
@@ -19,7 +19,8 @@ def format_request(bundle, kernel_language='no_spec'):
     Returns
     -------
     str
-        `REQUEST = "<json-encoded expression>"`
+        `REQUEST = "<json-encoded expression>"` by default or
+        `<a kernel_language specific variable name> = "<json-encoded expression>"`
     """
     bundle = json.dumps(bundle)
     if kernel_language.lower() == 'perl':

--- a/kernel_gateway/tests/notebook_http/test_request_utils.py
+++ b/kernel_gateway/tests/notebook_http/test_request_utils.py
@@ -148,7 +148,17 @@ class TestRequestUtils(unittest.TestCase):
         request_code = format_request(test_request)
         self.assertTrue(request_code.startswith("REQUEST"), "Call format_request without a kernel_language argument was not formatted correctly")
 
-    def test_format_request_with_a_kernel_language_arg(self):
+    def test_format_request_with_a_kernel_language_python(self):
+        test_request = ('''{"body": "", "headers": {}, "args": {}, "path": {}}''')
+        request_code = format_request(test_request, 'python')
+        self.assertTrue(request_code.startswith("REQUEST"), 'Call format_request without a kernel_language "python" was not formatted correctly')
+
+    def test_format_request_with_a_kernel_language_scala(self):
+        test_request = ('''{"body": "", "headers": {}, "args": {}, "path": {}}''')
+        request_code = format_request(test_request, 'scala')
+        self.assertTrue(request_code.startswith("REQUEST"), 'Call format_request without a kernel_language "scala" was not formatted correctly')
+
+    def test_format_request_with_a_kernel_language_perl(self):
         test_request = ('''{"body": "", "headers": {}, "args": {}, "path": {}}''')
         request_code = format_request(test_request, 'perl')
-        self.assertTrue(request_code.startswith("my $REQUEST"), "Call format_request with a kernel language argument was not formatted correctly")
+        self.assertTrue(request_code.startswith("my $REQUEST"), 'Call format_request with a kernel language "perl" was not formatted correctly')

--- a/kernel_gateway/tests/notebook_http/test_request_utils.py
+++ b/kernel_gateway/tests/notebook_http/test_request_utils.py
@@ -128,7 +128,7 @@ class TestRequestUtils(unittest.TestCase):
         test_request = ('''{"body": "", "headers": {"Accept-Language": "en-US,en;q=0.8",
                         "If-None-Match": "9a28a9262f954494a8de7442c63d6d0715ce0998",
                         "Accept-Encoding": "gzip, deflate, sdch"}, "args": {}, "path": {}}''')
-        request_code = format_request(test_request, 'python')
+        request_code = format_request(test_request)
         #Get the value of REQUEST = "{ to test for equality
         test_request_js_value = request_code[request_code.index("\"{"):]
         self.assertEqual(test_request, json.loads(test_request_js_value), "Request code without escaped quotes was not formatted correctly")
@@ -138,7 +138,7 @@ class TestRequestUtils(unittest.TestCase):
         test_request = ('''{"body": "", "headers": {"Accept-Language": "en-US,en;q=0.8",
                         "If-None-Match": "\"\"9a28a9262f954494a8de7442c63d6d0715ce0998\"\"",
                         "Accept-Encoding": "gzip, deflate, sdch"}, "args": {}, "path": {}}''')
-        request_code = format_request(test_request, 'python')
+        request_code = format_request(test_request)
         #Get the value of REQUEST = "{ to test for equality
         test_request_js_value = request_code[request_code.index("\"{"):]
         self.assertEqual(test_request, json.loads(test_request_js_value), "Escaped Request code was not formatted correctly")

--- a/kernel_gateway/tests/notebook_http/test_request_utils.py
+++ b/kernel_gateway/tests/notebook_http/test_request_utils.py
@@ -151,12 +151,12 @@ class TestRequestUtils(unittest.TestCase):
     def test_format_request_with_a_kernel_language_python(self):
         test_request = ('''{"body": "", "headers": {}, "args": {}, "path": {}}''')
         request_code = format_request(test_request, 'python')
-        self.assertTrue(request_code.startswith("REQUEST"), 'Call format_request without a kernel_language "python" was not formatted correctly')
+        self.assertTrue(request_code.startswith("REQUEST"), 'Call format_request with a kernel_language "python" was not formatted correctly')
 
     def test_format_request_with_a_kernel_language_scala(self):
         test_request = ('''{"body": "", "headers": {}, "args": {}, "path": {}}''')
         request_code = format_request(test_request, 'scala')
-        self.assertTrue(request_code.startswith("REQUEST"), 'Call format_request without a kernel_language "scala" was not formatted correctly')
+        self.assertTrue(request_code.startswith("REQUEST"), 'Call format_request with a kernel_language "scala" was not formatted correctly')
 
     def test_format_request_with_a_kernel_language_perl(self):
         test_request = ('''{"body": "", "headers": {}, "args": {}, "path": {}}''')

--- a/kernel_gateway/tests/notebook_http/test_request_utils.py
+++ b/kernel_gateway/tests/notebook_http/test_request_utils.py
@@ -128,7 +128,7 @@ class TestRequestUtils(unittest.TestCase):
         test_request = ('''{"body": "", "headers": {"Accept-Language": "en-US,en;q=0.8",
                         "If-None-Match": "9a28a9262f954494a8de7442c63d6d0715ce0998",
                         "Accept-Encoding": "gzip, deflate, sdch"}, "args": {}, "path": {}}''')
-        request_code = format_request(test_request)
+        request_code = format_request(test_request, 'python')
         #Get the value of REQUEST = "{ to test for equality
         test_request_js_value = request_code[request_code.index("\"{"):]
         self.assertEqual(test_request, json.loads(test_request_js_value), "Request code without escaped quotes was not formatted correctly")
@@ -138,7 +138,7 @@ class TestRequestUtils(unittest.TestCase):
         test_request = ('''{"body": "", "headers": {"Accept-Language": "en-US,en;q=0.8",
                         "If-None-Match": "\"\"9a28a9262f954494a8de7442c63d6d0715ce0998\"\"",
                         "Accept-Encoding": "gzip, deflate, sdch"}, "args": {}, "path": {}}''')
-        request_code = format_request(test_request)
+        request_code = format_request(test_request, 'python')
         #Get the value of REQUEST = "{ to test for equality
         test_request_js_value = request_code[request_code.index("\"{"):]
         self.assertEqual(test_request, json.loads(test_request_js_value), "Escaped Request code was not formatted correctly")

--- a/kernel_gateway/tests/notebook_http/test_request_utils.py
+++ b/kernel_gateway/tests/notebook_http/test_request_utils.py
@@ -142,3 +142,13 @@ class TestRequestUtils(unittest.TestCase):
         #Get the value of REQUEST = "{ to test for equality
         test_request_js_value = request_code[request_code.index("\"{"):]
         self.assertEqual(test_request, json.loads(test_request_js_value), "Escaped Request code was not formatted correctly")
+
+    def test_format_request_without_a_kernel_language_arg(self):
+        test_request = ('''{"body": "", "headers": {}, "args": {}, "path": {}}''')
+        request_code = format_request(test_request)
+        self.assertTrue(request_code.startswith("REQUEST"), "Call format_request without a kernel_language argument was not formatted correctly")
+
+    def test_format_request_with_a_kernel_language_arg(self):
+        test_request = ('''{"body": "", "headers": {}, "args": {}, "path": {}}''')
+        request_code = format_request(test_request, 'perl')
+        self.assertTrue(request_code.startswith("my $REQUEST"), "Call format_request with a kernel language argument was not formatted correctly")


### PR DESCRIPTION
When I try the notebook-http mode with the [IPerl kernel](https://github.com/EntropyOrg/p5-Devel-IPerl) and run into a constant variable assignment problem.

In Perl when we use a all-uppercase name like `REQUEST`, it means the variable is a constant. An assignment like `REQUEST = ...` is illegal, i.e. we can't use a "=" to assign a value to a constant variable. 

And in fact in Ruby the uppercase name is treated as a constant, too. But in Ruby the syntax `REQUEST = ...` is a valid assignment, it seems there's no problem with Ruby. And nor do Python.

So here I add a kernel dependent change to the `request_format` function. When the kernel is `iperl`, it takes `$REQUEST` as a variable that could be assigned a value with `=`.  And the way may be useful for some other kernels in such a situation.

 And I test it with a [IPerl notebook](https://github.com/gingerhot/my_notebooks/blob/master/Perl/test_kernel_gateway.ipynb) and it works.   