### PR TITLE
fix link to http-mode.html

### DIFF
--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -48,7 +48,7 @@ make dev
 
 Then access the running server at the URL printed in the console.
 
-Run an instance of the kernel gateway server in [`notebook-http` mode](http-mode) using the `api_intro.ipynb` notebook in the repository.
+Run an instance of the kernel gateway server in [`notebook-http` mode](http-mode.html) using the `api_intro.ipynb` notebook in the repository.
 
 ```bash
 make dev-http

--- a/docs/source/features.md
+++ b/docs/source/features.md
@@ -5,7 +5,7 @@ The Jupyter Kernel Gateway has the following features:
 * [`jupyter-websocket` mode](websocket-mode) which provides a 
   Jupyter Notebook server-compatible API for requesting kernels and
   communicating with them using Websockets
-* [`notebook-http` mode](http-mode) which maps HTTP requests to
+* [`notebook-http` mode](http-mode.html) which maps HTTP requests to
   cells in annotated notebooks
 * Option to enable other kernel communication mechanisms by plugging in third party personalities
 * Option to set a shared authentication token and require it from clients
@@ -18,7 +18,7 @@ The Jupyter Kernel Gateway has the following features:
   in the request
 * Option to pre-populate kernel memory from a notebook
 * Option to serve annotated notebooks as HTTP endpoints, see
-  [notebook-http](#notebook-http-mode)
+  [notebook-http](http-mode.html)
 * Option to allow downloading of the notebook source when running
   in `notebook-http` mode
 * Generation of [Swagger specs](http://swagger.io/introducing-the-open-api-initiative/)

--- a/docs/source/uses.md
+++ b/docs/source/uses.md
@@ -11,7 +11,7 @@ The Jupyter Kernel Gateway makes possible the following novel uses of kernels:
   [tmpnb](https://github.com/jupyter/tmpnb), [Binder](http://mybinder.org/),
   or your favorite cluster manager)
 * Create microservices from notebooks via 
-  [`notebook-http` mode](notebook-http-mode)
+  [`notebook-http` mode](http-mode.html)
 
 The following diagram shows how you might use `tmpnb` to deploy a pool of kernel gateway instances in Docker containers to support on-demand interactive compute:
 


### PR DESCRIPTION
Scratching my itch.
http://jupyter-kernel-gateway.readthedocs.io/en/latest/uses.html had a
bad link I clicked.

I should be doing this for the other links too, but I have to go to
sleep. ;)

This does not fix targets like PDF and man, but I guess HTML is the
primary use case anyways...