### PR TITLE
Add whitelist for environment variables to be inherited from gateway process by kernel.

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -179,6 +179,10 @@ KernelGatewayApp options
     Default: None
     Runs the notebook (.ipynb) at the given URI on every kernel launched. No
     seed by default. (KG_SEED_URI env var)
+--KernelGatewayApp.env_process_whitelist=<List>
+    Default: []
+    Environment variables allowed to be inherited from current process by a
+    new kernel.
 
 NotebookHTTPPersonality options
 -------------------------------

--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from traitlets import Unicode, Integer, default, observe, Type, Instance
+from traitlets import Unicode, Integer, default, observe, Type, Instance, List
 
 from jupyter_core.application import JupyterApp, base_aliases
 from jupyter_client.kernelspec import KernelSpecManager
@@ -232,6 +232,14 @@ class KernelGatewayApp(JupyterApp):
     def force_kernel_name_default(self):
         return os.getenv(self.force_kernel_name_env, '')
 
+    env_process_whitelist_env = 'KG_ENV_PROCESS_WHITELIST'
+    env_process_whitelist = List(config=True,
+                                 help="""Environment variables allowed to be inherited from the spawning process by the kernel""")
+
+    @default('env_process_whitelist')
+    def env_process_whitelist_default(self):
+        return os.getenv(self.env_process_whitelist_env, '').split(',')
+
     api_env = 'KG_API'
     api_default_value = 'kernel_gateway.jupyter_websocket'
     api = Unicode(api_default_value,
@@ -444,6 +452,7 @@ class KernelGatewayApp(JupyterApp):
             kg_expose_headers=self.expose_headers,
             kg_max_age=self.max_age,
             kg_max_kernels=self.max_kernels,
+            kg_env_process_whitelist=self.env_process_whitelist,
             kg_api=self.api,
             kg_personality=self.personality,
             # Also set the allow_origin setting used by notebook so that the


### PR DESCRIPTION
As raised in #279, this PR adds ability to define a whitelist of environment variables which are allowed to be inherited from the kernel gateway process, when spawning a kernel process. This is needed to allow environment variables such as ``LD_LIBRARY_PATH``, ``LD_PRELOAD`` or other special environment variables to be passed through when executing the kernel process. In the case of ``LD_LIBRARY_PATH`` this avoids error such as:

```
[KernelGatewayApp] KernelRestarter: restarting kernel (3/5), new random ports
[KernelGatewayApp] Starting kernel: ['/opt/app-root/bin/python3', '-m', 'ipykernel_launcher', '-f', '/opt/app-root/src/.local/share/jupyter/runtime/kernel-5f5bb348-3c3a-4ec5-aea2-fafba2c0cf3a.json']
/opt/app-root/bin/python3: error while loading shared libraries: libpython3.5m.so.rh-python35-1.0: cannot open shared object file: No such file or directory
```

The list of environment variables allowed to be inherited can be set by ``KG_ENV_PROCESS_WHITELIST`` or ``KernelGatewayApp.env_process_whitelist``. Used ``env_process_whitelist`` instead of ``process_whitelist`` on ``KernelGatewayApp`` in the end so clearly distinguished from ``JupyterWebsocketPersonality.env_whitelist`` which is whitelist of environment variables that can be passed from client making request to start kernel. Need to be different to also avoid conflict with ``KG_ENV_WHITELIST`` environment variable.