### PR TITLE
Limit tornado version to avoid build issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ jupyter_core>=4.0
 jupyter_client>=4.2.0
 notebook>=5.0.0
 traitlets>=4.2.0
-tornado>=4.2.0
+tornado>=4.2.0,<5.0
 requests>=2.7,<3.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ containerized and scaled out using common technologies like
         'jupyter_client>=4.2.0',
         'notebook>=5.0.0,<6.0',
         'traitlets>=4.2.0',
-        'tornado>=4.2.0',
+        'tornado>=4.2.0,<5.0',
         'requests>=2.7,<3.0'
     ],
     classifiers=[


### PR DESCRIPTION
Tornado version 5.0 was recently released and introduces significant
changes. One change that breaks Travis builds is the removal of the
tornado.testing.LogTrapTestCase. Attempts to remove that reference
still lead to failures. This change mostly limit the tornado version
to temporarily avoid build issues.