### PR TITLE
Add reason argument to set_status() so that custom messages flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ docs/_build/
 # PyBuilder
 target/
 
+# PyCharm
+.idea/
+
 .DS_Store
 .ipynb_checkpoints/

--- a/kernel_gateway/mixins.py
+++ b/kernel_gateway/mixins.py
@@ -125,5 +125,5 @@ class JSONErrorsMixin(object):
                 reply['reason'] = custom_reason
 
         self.set_header('Content-Type', 'application/json')
-        self.set_status(status_code)
+        self.set_status(status_code, reason=reply['reason'])
         self.finish(json.dumps(reply))

--- a/kernel_gateway/tests/test_mixins.py
+++ b/kernel_gateway/tests/test_mixins.py
@@ -137,12 +137,18 @@ class TestableJSONErrorsHandler(JSONErrorsMixin):
         self.headers = {}
         self.response = None
         self.status_code = None
+        self.reason = None
 
     def finish(self, response):
         self.response = response
 
-    def set_status(self, status_code):
+    def set_status(self, status_code, reason=None):
+        # The reason parameter is essentially ignored, but necessary in the signature
+        # in order for custom messages to be returned to the client from tornado.
+        # Tornado's set_status method takes both parameters setting internal members
+        # to both values.  For now, we'll set the member but not use it.
         self.status_code = status_code
+        self.reason = reason
 
     def set_header(self, name, value):
         self.headers[name] = value


### PR DESCRIPTION
Without adding a named argument of `reason` to tornado's `set_status()`
method, messages associated with a thrown HTTPError will not be returned
to the caller.  Instead, the reason corresponding to the built-in status
code is returned.  In addition, because the reason argument is used,
enforcement of a built in status code is skipped, thereby allowing for
the optional use of non-builtin status codes.

Fixes #283