### PR TITLE
adds x_header configuration option for use behind proxies

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from traitlets import Unicode, Integer, default, observe, Type, Instance, List
+from traitlets import Unicode, Integer, default, observe, Type, Instance, List, CBool
 
 from jupyter_core.application import JupyterApp, base_aliases
 from jupyter_client.kernelspec import KernelSpecManager
@@ -176,12 +176,12 @@ class KernelGatewayApp(JupyterApp):
         return os.getenv(self.expose_headers_env, '')
 
     trust_xheaders_env = 'KG_TRUST_XHEADERS'
-    trust_xheaders = Unicode(config=True,
+    trust_xheaders = CBool(False, config=True,
         help='Use x-* header values for overriding the remote-ip, useful when application is behing a proxy. (KG_TRUST_XHEADERS env var)'
     )
     @default('trust_xheaders')
     def trust_xheaders_default(self):
-        return os.getenv(self.trust_xheaders_env, 'False')
+        return strtobool(os.getenv(self.trust_xheaders_env, 'False'))
 
 
     max_age_env = 'KG_MAX_AGE'
@@ -515,7 +515,7 @@ class KernelGatewayApp(JupyterApp):
         """
         ssl_options = self._build_ssl_options()
         self.http_server = httpserver.HTTPServer(self.web_app,
-                                                 xheaders=strtobool(self.trust_xheaders),
+                                                 xheaders=self.trust_xheaders,
                                                  ssl_options=ssl_options)
 
         for port in random_ports(self.port, self.port_retries+1):

--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -9,7 +9,7 @@ import logging
 import nbformat
 import importlib
 import signal
-
+from distutils.util import strtobool
 from notebook.services.kernels.kernelmanager import MappingKernelManager
 
 try:
@@ -173,6 +173,16 @@ class KernelGatewayApp(JupyterApp):
     @default('expose_headers')
     def expose_headers_default(self):
         return os.getenv(self.expose_headers_env, '')
+
+    x_headers_env = 'KG_X_HEADERS'
+    x_headers = Unicode(config=True,
+        help='Uses x-* header values for overriding the remote-ip, useful when application is behing a proxy. (KG_X_HEADERS env var)'
+    )
+
+    @default('x_headers')
+    def x_headers_default(self):
+        return os.getenv(self.x_headers_env, 'false')
+
 
     max_age_env = 'KG_MAX_AGE'
     max_age = Unicode(config=True,
@@ -505,6 +515,7 @@ class KernelGatewayApp(JupyterApp):
         """
         ssl_options = self._build_ssl_options()
         self.http_server = httpserver.HTTPServer(self.web_app,
+                                                 xheaders=bool(strtobool(self.x_headers)),
                                                  ssl_options=ssl_options)
 
         for port in random_ports(self.port, self.port_retries+1):

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -43,6 +43,8 @@ class TestGatewayAppConfig(unittest.TestCase):
         os.environ['KG_KEYFILE'] = '/test/fake.key'
         os.environ['KG_CERTFILE'] = '/test/fake.crt'
         os.environ['KG_CLIENT_CA'] = '/test/fake_ca.crt'
+        os.environ['KG_X_HEADERS'] = 'true'
+
 
         app = KernelGatewayApp()
 
@@ -65,6 +67,7 @@ class TestGatewayAppConfig(unittest.TestCase):
         self.assertEqual(app.keyfile, '/test/fake.key')
         self.assertEqual(app.certfile, '/test/fake.crt')
         self.assertEqual(app.client_ca, '/test/fake_ca.crt')
+        self.assertEqual(app.x_headers, 'true')
 
 class TestGatewayAppBase(AsyncHTTPTestCase, ExpectLog):
     """Base class for integration style tests using HTTP/Websockets against an

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -43,7 +43,7 @@ class TestGatewayAppConfig(unittest.TestCase):
         os.environ['KG_KEYFILE'] = '/test/fake.key'
         os.environ['KG_CERTFILE'] = '/test/fake.crt'
         os.environ['KG_CLIENT_CA'] = '/test/fake_ca.crt'
-        os.environ['KG_X_HEADERS'] = 'true'
+        os.environ['KG_TRUST_XHEADERS'] = 'true'
 
 
         app = KernelGatewayApp()
@@ -67,7 +67,7 @@ class TestGatewayAppConfig(unittest.TestCase):
         self.assertEqual(app.keyfile, '/test/fake.key')
         self.assertEqual(app.certfile, '/test/fake.crt')
         self.assertEqual(app.client_ca, '/test/fake_ca.crt')
-        self.assertEqual(app.x_headers, 'true')
+        self.assertEqual(app.trust_xheaders, True)
 
 class TestGatewayAppBase(AsyncHTTPTestCase, ExpectLog):
     """Base class for integration style tests using HTTP/Websockets against an

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -43,7 +43,7 @@ class TestGatewayAppConfig(unittest.TestCase):
         os.environ['KG_KEYFILE'] = '/test/fake.key'
         os.environ['KG_CERTFILE'] = '/test/fake.crt'
         os.environ['KG_CLIENT_CA'] = '/test/fake_ca.crt'
-        os.environ['KG_TRUST_XHEADERS'] = 'true'
+        os.environ['KG_TRUST_XHEADERS'] = 'false'
 
 
         app = KernelGatewayApp()
@@ -67,7 +67,17 @@ class TestGatewayAppConfig(unittest.TestCase):
         self.assertEqual(app.keyfile, '/test/fake.key')
         self.assertEqual(app.certfile, '/test/fake.crt')
         self.assertEqual(app.client_ca, '/test/fake_ca.crt')
-        self.assertEqual(app.trust_xheaders, 'true')
+        self.assertEqual(app.trust_xheaders, False)
+
+    def test_trust_xheaders(self):
+
+        app = KernelGatewayApp()
+        self.assertEqual(app.trust_xheaders, False)
+        os.environ['KG_TRUST_XHEADERS'] = 'true'
+        app = KernelGatewayApp()
+        self.assertEqual(app.trust_xheaders, True)
+
+
 
 class TestGatewayAppBase(AsyncHTTPTestCase, ExpectLog):
     """Base class for integration style tests using HTTP/Websockets against an

--- a/kernel_gateway/tests/test_gatewayapp.py
+++ b/kernel_gateway/tests/test_gatewayapp.py
@@ -67,7 +67,7 @@ class TestGatewayAppConfig(unittest.TestCase):
         self.assertEqual(app.keyfile, '/test/fake.key')
         self.assertEqual(app.certfile, '/test/fake.crt')
         self.assertEqual(app.client_ca, '/test/fake_ca.crt')
-        self.assertEqual(app.trust_xheaders, True)
+        self.assertEqual(app.trust_xheaders, 'true')
 
 class TestGatewayAppBase(AsyncHTTPTestCase, ExpectLog):
     """Base class for integration style tests using HTTP/Websockets against an


### PR DESCRIPTION
This passes the xheaders configuration option to tornado. The option informs tornado to use the forwarded X-Real-Ip header if given. Useful for when the kernelgateway is behind a proxy and you need the original ip (for logging for instance). 