### PR TITLE
Sync CHANGELOG.md with 1.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 * Fix security requirements in the swagger spec
 * Fix configured headers for OPTIONS requests
 
+## 1.2.2 (2017-05-30)
+
+* Inherit the server `PATH` when launching a new kernel via POST request
+  with custom environment variables
+* Fix kernel cleanup upon SIGTERM
+
 ## 1.2.1 (2017-04-01)
 
 * Add support for auth token as a query parameter

--- a/docs/source/summary-changes.md
+++ b/docs/source/summary-changes.md
@@ -26,6 +26,12 @@ See `git log` for a more detailed summary of changes.
 
 ## 1.2
 
+### 1.2.2 (2017-05-30)
+
+* Inherit the server `PATH` when launching a new kernel via POST request
+  with custom environment variables
+* Fix kernel cleanup upon SIGTERM
+
 ### 1.2.1 (2017-04-01)
 
 * Add support for auth token as a query parameter


### PR DESCRIPTION
The changelog on the master branch is missing the entry for release 1.2.2 in the 1.2.x branch:
https://raw.githubusercontent.com/jupyter/kernel_gateway/1.2.x/CHANGELOG.md