### PR TITLE
features.md: Fix a link typo

### DIFF
--- a/docs/source/features.md
+++ b/docs/source/features.md
@@ -2,7 +2,7 @@
 
 The Jupyter Kernel Gateway has the following features:
 
-* [`jupyter-websocket` mode](websocket-mode) which provides a 
+* [`jupyter-websocket` mode](websocket-mode.html) which provides a 
   Jupyter Notebook server-compatible API for requesting kernels and
   communicating with them using Websockets
 * [`notebook-http` mode](http-mode.html) which maps HTTP requests to


### PR DESCRIPTION
https://jupyter-kernel-gateway.readthedocs.io/en/latest/websocket-mode is 404, while https://jupyter-kernel-gateway.readthedocs.io/en/latest/websocket-mode.html is 200.