### PR TITLE
Support serving kernelspec resources

### DIFF
--- a/kernel_gateway/services/kernelspecs/handlers.py
+++ b/kernel_gateway/services/kernelspecs/handlers.py
@@ -3,12 +3,19 @@
 """Tornado handlers for kernel specs."""
 
 import notebook.services.kernelspecs.handlers as notebook_handlers
+import notebook.kernelspecs.handlers as notebook_kernelspecs_resources_handlers
+
 from ...mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 
 # Extends the default handlers from the notebook package with token auth, CORS
 # and JSON errors.
 default_handlers = []
 for path, cls in notebook_handlers.default_handlers:
+    # Everything should have CORS and token auth
+    bases = (TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin, cls)
+    default_handlers.append((path, type(cls.__name__, bases, {})))
+
+for path, cls in notebook_kernelspecs_resources_handlers.default_handlers:
     # Everything should have CORS and token auth
     bases = (TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin, cls)
     default_handlers.append((path, type(cls.__name__, bases, {})))


### PR DESCRIPTION
A long-standing TODO item for NB2KG was to add support for kernelspec resources (`kernel.js`, `kernel.css` and `logo-*`).  This can't be accomplished until JKG provides the endpoint such that specific resources can be fetched.  This change hooks up the Notebook's kernelspecs resource handler - after which requests specifying the kernelspec name and file within will be returned:
`http://127.0.0.1:8889/kernelspecs/python3/logo-64x64.png`.