### PR TITLE
Fix handler to be more compatible with tornado/pyzmq updates

### DIFF
--- a/kernel_gateway/jupyter_websocket/handlers.py
+++ b/kernel_gateway/jupyter_websocket/handlers.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 """Tornado handlers for kernel specs."""
 
+from notebook.utils import maybe_future
 from tornado import gen, web
 from ..mixins import TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin
 import os
@@ -29,7 +30,7 @@ class BaseSpecHandler(CORSMixin, web.StaticFileHandler):
         resource_name, content_type = self.get_resource_metadata()
         self.set_header('Content-Type', content_type)
         res = web.StaticFileHandler.get(self, resource_name)
-        yield gen.maybe_future(res)
+        yield maybe_future(res)
 
     def options(self, **kwargs):
         """Method for properly handling CORS pre-flight"""


### PR DESCRIPTION
This addresses build issues related to allowing Notebook 6 support (#321).  However, I'm suspicious of `jupyter_client 5.3.1` which may be causing this issue near the end of the tests...
```
Exception in thread Thread-31:
Traceback (most recent call last):
  File "/opt/anaconda3/envs/kernel-gateway-dev/lib/python3.6/threading.py", line 916, in _bootstrap_inner
  File "/opt/anaconda3/envs/kernel-gateway-dev/lib/python3.6/site-packages/jupyter_client/channels.py", line 167, in run
  File "/opt/anaconda3/envs/kernel-gateway-dev/lib/python3.6/site-packages/jupyter_client/channels.py", line 94, in _create_socket
  File "/opt/anaconda3/envs/kernel-gateway-dev/lib/python3.6/site-packages/zmq/sugar/context.py", line 146, in socket
  File "/opt/anaconda3/envs/kernel-gateway-dev/lib/python3.6/site-packages/zmq/sugar/socket.py", line 59, in __init__
  File "zmq/backend/cython/socket.pyx", line 328, in zmq.backend.cython.socket.Socket.__init__
zmq.error.ZMQError: Too many open files
```
We should revisit this issue once this PR is merged and we can see how PR #321 behaves.