### PR TITLE
fix: module 'signal' has no attribute 'SIGHUP' on Windows

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -6,6 +6,7 @@ import errno
 import importlib
 import logging
 import os
+import sys
 import signal
 import socket
 from distutils.util import strtobool
@@ -546,7 +547,8 @@ class KernelGatewayApp(JupyterApp):
         ))
         self.io_loop = ioloop.IOLoop.current()
 
-        signal.signal(signal.SIGHUP, signal.SIG_IGN)
+        if sys.platform != 'win32':
+            signal.signal(signal.SIGHUP, signal.SIG_IGN)
 
         signal.signal(signal.SIGTERM, self._signal_stop)
 


### PR DESCRIPTION
Fix error on Windows that was introduced by change:
https://github.com/jupyter/kernel_gateway/commit/50cbbeb24d021464e5f0f379c8bd3fd2b8c6df2a
=============================================

(base) v:>jupyter kernelgateway
[KernelGatewayApp] Jupyter Kernel Gateway at http://127.0.0.1:8888
Traceback (most recent call last):
File "C:\Anaconda3\Scripts\jupyter-kernelgateway-script.py", line 9, in
sys.exit(launch_instance())
File "C:\Anaconda3\lib\site-packages\jupyter_core\application.py", line 267, in launch_instance
return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
File "C:\Anaconda3\lib\site-packages\traitlets\config\application.py", line 658, in launch_instance
app.start()
File "C:\Anaconda3\lib\site-packages\kernel_gateway\gatewayapp.py", line 549, in start
signal.signal(signal.SIGHUP, signal.SIG_IGN)
AttributeError: module 'signal' has no attribute 'SIGHUP'

