### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/kernel_gateway/notebook_http/request_utils.py
+++ b/kernel_gateway/notebook_http/request_utils.py
@@ -65,7 +65,7 @@ def parse_body(request):
     """
     content_type = TEXT_PLAIN
     body = request.body
-    body = '' if body is b'' or body is None else body.decode(encoding='UTF-8')
+    body = body.decode(encoding='UTF-8') if body else ''
     if 'Content-Type' in request.headers:
         content_type = request.headers['Content-Type']
     return_body = body


### PR DESCRIPTION
Identity is not the same thing as equality in Python.

[Porting to Python 3.8](https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8)
> The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in bpo-34850.)

flake8 testing of https://github.com/jupyter/kernel_gateway on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./kernel_gateway/notebook_http/request_utils.py:68:18: F632 use ==/!= to compare str, bytes, and int literals
    body = '' if body is b'' or body is None else body.decode(encoding='UTF-8')
                 ^
1     F632 use ==/!= to compare str, bytes, and int literals
1
```