### PR TITLE
Use appropriate maybe-future to handle asyncio futures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ dist: xenial   # required for Python >= 3.7
 sudo: false
 language: python
 python:
-    - 2.7
-    - 3.4
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
 
 env:
     - ASYNC_TEST_TIMEOUT=10

--- a/kernel_gateway/services/kernels/manager.py
+++ b/kernel_gateway/services/kernels/manager.py
@@ -5,6 +5,7 @@
 from functools import partial
 from tornado import gen, ioloop
 from notebook.services.kernels.kernelmanager import MappingKernelManager
+from notebook.utils import maybe_future
 from jupyter_client.ioloop import IOLoopKernelManager
 
 class SeedingMappingKernelManager(MappingKernelManager):
@@ -78,7 +79,7 @@ class SeedingMappingKernelManager(MappingKernelManager):
         """
         if self.parent.force_kernel_name:
             kwargs['kernel_name'] = self.parent.force_kernel_name
-        kernel_id = yield gen.maybe_future(super(SeedingMappingKernelManager, self).start_kernel(*args, **kwargs))
+        kernel_id = yield maybe_future(super(SeedingMappingKernelManager, self).start_kernel(*args, **kwargs))
 
         if kernel_id and self.seed_source is not None:
             # Only run source if the kernel spec matches the notebook kernel spec

--- a/kernel_gateway/services/sessions/sessionmanager.py
+++ b/kernel_gateway/services/sessions/sessionmanager.py
@@ -3,6 +3,7 @@
 """Session manager that keeps all its metadata in memory."""
 
 import uuid
+from notebook.utils import maybe_future
 from tornado import web, gen
 from traitlets.config.configurable import LoggingConfigurable
 from ipython_genutils.py3compat import unicode_type
@@ -71,10 +72,8 @@ class SessionManager(LoggingConfigurable):
         """
         session_id = self.new_session_id()
         # allow nbm to specify kernels cwd
-        kernel_id = yield gen.maybe_future(self.kernel_manager.start_kernel(path=path,
-                                                                            kernel_name=kernel_name))
-        raise gen.Return(self.save_session(session_id, path=path,
-                                           kernel_id=kernel_id))
+        kernel_id = yield maybe_future(self.kernel_manager.start_kernel(path=path, kernel_name=kernel_name))
+        raise gen.Return(self.save_session(session_id, path=path, kernel_id=kernel_id))
 
     def save_session(self, session_id, path=None, kernel_id=None, *args, **kwargs):
         """Saves the metadata for the session with the given `session_id`.


### PR DESCRIPTION
The method to handle conditional returns of futures in tornado was both deprecated and incompatible with asyncio.  This incompatibility surfaces with Notebook 6.1 since it uses asyncio. Now using `maybe_future` from `notebook.utils` instead.

Updated the python matrix in Travis.

Fixes #337