### PR TITLE
Formally define traits in swagger parser

### DIFF
--- a/kernel_gateway/notebook_http/cell/parser.py
+++ b/kernel_gateway/notebook_http/cell/parser.py
@@ -4,6 +4,7 @@
 
 import re
 import sys
+from traitlets import Unicode
 from traitlets.config.configurable import LoggingConfigurable
 
 def first_path_param_index(endpoint):
@@ -63,8 +64,8 @@ class APICellParser(LoggingConfigurable):
     api_response_indicator : str
         Regex pattern for API response metadata annotations
     """
-    api_indicator = r'{}\s+(GET|PUT|POST|DELETE)\s+(\/.*)+'
-    api_response_indicator = r'{}\s+ResponseInfo\s+(GET|PUT|POST|DELETE)\s+(\/.*)+'
+    api_indicator = Unicode(default_value=r'{}\s+(GET|PUT|POST|DELETE)\s+(\/.*)+')
+    api_response_indicator = Unicode(default_value=r'{}\s+ResponseInfo\s+(GET|PUT|POST|DELETE)\s+(\/.*)+')
 
     def __init__(self, comment_prefix, *args, **kwargs):
         super(APICellParser, self).__init__(*args, **kwargs)

--- a/kernel_gateway/notebook_http/swagger/parser.py
+++ b/kernel_gateway/notebook_http/swagger/parser.py
@@ -5,7 +5,7 @@
 import json
 import re
 from kernel_gateway.notebook_http.cell.parser import first_path_param_index, APICellParser
-from traitlets import default
+from traitlets import List, Unicode
 from traitlets.config.configurable import LoggingConfigurable
 
 def _swaggerlet_from_markdown(cell_source):
@@ -62,9 +62,9 @@ class SwaggerCellParser(LoggingConfigurable):
     operation_response_indicator : str
         Regex pattern for API response metadata annotations
     """
-    operation_indicator = r'{}\s*operationId:\s*(.*)'
-    operation_response_indicator = r'{}\s*ResponseInfo\s+operationId:\s*(.*)'
-    notebook_cells = []
+    operation_indicator = Unicode(default_value=r'{}\s*operationId:\s*(.*)')
+    operation_response_indicator = Unicode(default_value=r'{}\s*ResponseInfo\s+operationId:\s*(.*)')
+    notebook_cells = List()
 
     def __init__(self, comment_prefix, *args, **kwargs):
         super(SwaggerCellParser, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The CI tests for Python 3.7 and 3.8 have started failing recently.  It turns out the traitlets 5.0.4 release has removed some deprecated functionality from traitlets 4.2.  Since the older python tests still use 4.3.3, they continue working.  The removed functionality had to do with member fields getting initialized from same-named keyword arguments without having been "typed" as a trait.

By defining these fields as traits, the expected initialization from keyword arguments occurs (on both versions of traitlets).