### PR TITLE
Fix all warnings (but 2) when doing make html

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,8 +1,13 @@
 name: kernel_gateway_docs
+channels:
+  - defaults
+  - conda-forge
 dependencies:
-- python=3.7
-- sphinx_rtd_theme
-- sphinx
-- pip
-- pip:
-    - recommonmark
+  - python=3.7
+  - sphinx
+  - sphinx_rtd_theme
+  - recommonmark
+  - pillow
+  - pip
+  - pip:
+      - readthedocs-sphinx-ext

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,7 +1,8 @@
 name: kernel_gateway_docs
 dependencies:
-- python=3.5
+- python=3.7
 - sphinx_rtd_theme
 - sphinx
+- pip
 - pip:
     - recommonmark

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -152,7 +152,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -40,7 +40,7 @@ make test
 
 ### Run the gateway server
 
-Run an instance of the kernel gateway server in [`jupyter-websocket` mode](websocket-mode).
+Run an instance of the kernel gateway server in [`jupyter-websocket` mode](websocket-mode.md).
 
 ```bash
 make dev
@@ -48,7 +48,7 @@ make dev
 
 Then access the running server at the URL printed in the console.
 
-Run an instance of the kernel gateway server in [`notebook-http` mode](http-mode.html) using the `api_intro.ipynb` notebook in the repository.
+Run an instance of the kernel gateway server in [`notebook-http` mode](http-mode.md) using the `api_intro.ipynb` notebook in the repository.
 
 ```bash
 make dev-http

--- a/docs/source/features.md
+++ b/docs/source/features.md
@@ -2,10 +2,10 @@
 
 The Jupyter Kernel Gateway has the following features:
 
-* [`jupyter-websocket` mode](websocket-mode.html) which provides a 
+* [`jupyter-websocket` mode](websocket-mode.md) which provides a 
   Jupyter Notebook server-compatible API for requesting kernels and
   communicating with them using Websockets
-* [`notebook-http` mode](http-mode.html) which maps HTTP requests to
+* [`notebook-http` mode](http-mode.md) which maps HTTP requests to
   cells in annotated notebooks
 * Option to enable other kernel communication mechanisms by plugging in third party personalities
 * Option to set a shared authentication token and require it from clients
@@ -18,7 +18,7 @@ The Jupyter Kernel Gateway has the following features:
   in the request
 * Option to pre-populate kernel memory from a notebook
 * Option to serve annotated notebooks as HTTP endpoints, see
-  [notebook-http](http-mode.html)
+  [notebook-http](http-mode.md)
 * Option to allow downloading of the notebook source when running
   in `notebook-http` mode
 * Generation of [Swagger specs](http://swagger.io/introducing-the-open-api-initiative/)

--- a/docs/source/uses.md
+++ b/docs/source/uses.md
@@ -11,7 +11,7 @@ The Jupyter Kernel Gateway makes possible the following novel uses of kernels:
   [tmpnb](https://github.com/jupyter/tmpnb), [Binder](http://mybinder.org/),
   or your favorite cluster manager)
 * Create microservices from notebooks via 
-  [`notebook-http` mode](http-mode.html)
+  [`notebook-http` mode](http-mode.md)
 
 The following diagram shows how you might use `tmpnb` to deploy a pool of kernel gateway instances in Docker containers to support on-demand interactive compute:
 


### PR DESCRIPTION
Currently when I run 
```
cd docs
conda env create --file environment.yml
conda activate kernel_gateway_docs
make html
```
I get this output
```
sphinx-build -b html -d build/doctrees  -n source build/html
Running Sphinx v3.2.1
making output directory... done
WARNING: html_static_path entry '_static' does not exist
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 11 source files that are out of date
updating environment: [new config] 11 added, 0 changed, 0 removed
/home/marc/miniconda3/envs/kernel_gateway_docs/lib/python3.5/site-packages/recommonmark/parser.py:75: UserWarning: Container node skipped: type=document
  warn("Container node skipped: type={0}".format(mdnode.t))
reading sources... [100%] websocket-mode                                        
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] websocket-mode                                         
/home/marc/GitHub/kernel_gateway/docs/source/devinstall.md:51: WARNING: None:any reference target not found: http-mode.html
/home/marc/GitHub/kernel_gateway/docs/source/features.md:5: WARNING: None:any reference target not found: websocket-mode.html
/home/marc/GitHub/kernel_gateway/docs/source/features.md:8: WARNING: None:any reference target not found: http-mode.html
/home/marc/GitHub/kernel_gateway/docs/source/features.md:20: WARNING: None:any reference target not found: http-mode.html
/home/marc/GitHub/kernel_gateway/docs/source/plug-in.md:39: WARNING: None:any reference target not found: _modules/kernel_gateway/jupyter_websocket.html
/home/marc/GitHub/kernel_gateway/docs/source/plug-in.md:39: WARNING: None:any reference target not found: _modules/kernel_gateway/notebook_http.html
/home/marc/GitHub/kernel_gateway/docs/source/uses.md:13: WARNING: None:any reference target not found: http-mode.html
generating indices...  genindexdone
writing additional pages...  searchdone
copying images... [100%] images/kg_basic.png                                    
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 8 warnings.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
```
With this PR, the output is, instead:
```
sphinx-build -b html -d build/doctrees  -n source build/html
Running Sphinx v3.2.1
making output directory... done
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 11 source files that are out of date
updating environment: [new config] 11 added, 0 changed, 0 removed
/home/marc/miniconda3/envs/kernel_gateway_docs/lib/python3.5/site-packages/recommonmark/parser.py:75: UserWarning: Container node skipped: type=document
  warn("Container node skipped: type={0}".format(mdnode.t))
reading sources... [100%] websocket-mode                                                                                           
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] websocket-mode                                                                                            
/home/marc/GitHub/kernel_gateway/docs/source/plug-in.md:39: WARNING: None:any reference target not found: _modules/kernel_gateway/jupyter_websocket.html
/home/marc/GitHub/kernel_gateway/docs/source/plug-in.md:39: WARNING: None:any reference target not found: _modules/kernel_gateway/notebook_http.html
generating indices...  genindexdone
writing additional pages...  searchdone
copying images... [100%] images/kg_basic.png                                                                                       
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 2 warnings.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
```
For the two remaining warnings I assume they should point out to the documentation for the `jupyter_websocket` or `notebook_http` modules, but ATM I don't know how to generate that documentation.