### PR TITLE
Add preflight and delete option in sessions handler

### DIFF
--- a/kernel_gateway/services/sessions/handlers.py
+++ b/kernel_gateway/services/sessions/handlers.py
@@ -27,6 +27,23 @@ class SessionRootHandler(TokenAuthorizationMixin,
         else:
             super(SessionRootHandler, self).get()
 
+class SessionHandler(TokenAuthorizationMixin,
+                    CORSMixin,
+                    JSONErrorsMixin,
+                    notebook_handlers.SessionHandler):
+    """Extends the notebook session handler with token auth, CORS, and
+    JSON errors.
+    """
+    def set_default_headers(self):
+        self.set_header('Content-Type', 'application/json')
+        self.set_header('Access-Control-Allow-Origin', '*')
+        self.set_header('Access-Control-Allow-Headers', 'content-type')
+        self.set_header('Access-Control-Allow-Methods', 'DELETE')
+
+    def options(self, **kwargs):
+        """Method for properly handling CORS pre-flight"""
+        self.finish()
+
 default_handlers = []
 for path, cls in notebook_handlers.default_handlers:
     if cls.__name__ in globals():


### PR DESCRIPTION
When try to call a delete session, /api/sessions/<session_id> we obtain a preflight error and cors. See screenshots for more info:

![image](https://user-images.githubusercontent.com/1345596/119404296-e7588880-bcdf-11eb-9c28-a22510c5430f.png)

![image](https://user-images.githubusercontent.com/1345596/119404267-db6cc680-bcdf-11eb-8d94-95cba6d95db2.png)

I solve adding a new handler and allowing options call for preflight and adding delete options in headers. (Maybe is not all correct for integration because I don't read full kernel_gateway code) But this works fine and solve the issue.

This issue looks like appears in #297 too.