### PR TITLE
Pass `self.base_url` to Tornado constructor

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -482,6 +482,8 @@ class KernelGatewayApp(JupyterApp):
             # Also set the allow_origin setting used by notebook so that the
             # check_origin method used everywhere respects the value
             allow_origin=self.allow_origin,
+            # Set base_url for use in request handlers
+            base_url=self.base_url,
             # Always allow remote access (has been limited to localhost >= notebook 5.6)
             allow_remote_access=True
         )


### PR DESCRIPTION
Minor change as per https://github.com/jupyter/enterprise_gateway/issues/1017

Should make the kernelspec generation respect the configured `KG_BASE_URL` config.