### PR TITLE
fixed incorrect swagger.yaml

### DIFF
--- a/kernel_gateway/jupyter_websocket/swagger.json
+++ b/kernel_gateway/jupyter_websocket/swagger.json
@@ -403,7 +403,7 @@
           "type": "string",
           "description": "Unique name for kernel"
         },
-        "KernelSpecFile": {
+        "spec": {
           "$ref": "#/definitions/KernelSpecFile",
           "description": "Kernel spec json file"
         },

--- a/kernel_gateway/jupyter_websocket/swagger.yaml
+++ b/kernel_gateway/jupyter_websocket/swagger.yaml
@@ -299,7 +299,7 @@ definitions:
       name:
         type: string
         description: Unique name for kernel
-      KernelSpecFile:
+      spec:
         $ref: "#/definitions/KernelSpecFile"
         description: Kernel spec json file
       resources:


### PR DESCRIPTION
Fixes #404 

In `swagger.yaml`, under `definitions/KernelSpec`, there is a `KernelSpecFile` property defined instead of the returned `spec`.